### PR TITLE
Use JaCoCo offline instrumentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
       script:
         - sudo apt-get install jq
         - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r .assets[0].browser_download_url)
-        - mvn test jacoco:report coveralls:report sonar:sonar
+        - mvn clean verify coveralls:report sonar:sonar
         - java -jar ~/codacy-coverage-reporter-assembly-latest.jar report -l Java -r target/site/jacoco/jacoco.xml
 
 cache:

--- a/pom.xml
+++ b/pom.xml
@@ -293,26 +293,37 @@
                         <artifactId>jacoco-maven-plugin</artifactId>
                         <version>0.8.1</version>
                         <executions>
-                            <!-- Prepares the property pointing to the JaCoCo
-                            runtime agent which is passed as VM argument when Maven the Surefire plugin
-                            is executed. -->
                             <execution>
-                                <id>pre-unit-test</id>
+                                <id>default-prepare-agent</id>
                                 <goals>
                                     <goal>prepare-agent</goal>
                                 </goals>
                             </execution>
-
-                            <!-- Ensures that the code coverage report for
-                            unit tests is created after unit tests have been run. -->
                             <execution>
-                                <id>post-unit-test</id>
-                                <phase>test</phase>
+                                <id>jacoco-instrument</id>
+                                <goals>
+                                    <goal>instrument</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>jacoco-restore-instrumented-classes</id>
+                                <goals>
+                                    <goal>restore-instrumented-classes</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>jacoco-report</id>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>report</goal>
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <excludes>
+                                <exclude>*</exclude>
+                            </excludes>
+                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.eluder.coveralls</groupId>


### PR DESCRIPTION
Use JaCoCo offline instrumentation to record coverage for PowerMock-based tests
https://github.com/powermock/powermock/wiki/Code-coverage-with-JaCoCo