### PR TITLE
Stop using junit-platform-surefire-provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <slf4j.version>1.8.0-beta2</slf4j.version>
         <junit.version>4.12</junit.version>
         <junit5.version>5.3.1</junit5.version>
-        <junit.platform.version>1.3.1</junit.platform.version>
         <mockito.version>2.22.0</mockito.version>
         <powermock.version>2.0.0-beta.5</powermock.version>
     </properties>
@@ -172,13 +171,6 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.0</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>${junit.platform.version}</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
                     <includes>
                         <include>**/*.java</include>


### PR DESCRIPTION
The junit-platform-surefire-provider has been deprecated and is scheduled to
be removed in JUnit Platform 1.4. Please use the built-in support in Maven
Surefire >= 2.22.0 instead.
» https://junit.org/junit5/docs/current/user-guide/#running-tests-build-maven