### PR TITLE
Use Ubuntu Trusty on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 
 jdk:


### PR DESCRIPTION
https://travis-ci.community/t/solved-oraclejdk8-installation-failing-still-again/3428