### PR TITLE
Add initial AssertJ assertions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,13 @@
             <version>2.10.10</version>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.20.2</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
@@ -128,6 +135,12 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/com/github/valfirst/slf4jtest/AbstractTestLoggerAssert.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/AbstractTestLoggerAssert.java
@@ -1,0 +1,28 @@
+package com.github.valfirst.slf4jtest;
+
+import org.assertj.core.api.AbstractAssert;
+import uk.org.lidalia.slf4jext.Level;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+abstract class AbstractTestLoggerAssert<C extends AbstractAssert<C, TestLogger>> extends AbstractAssert<C, TestLogger> {
+    protected AbstractTestLoggerAssert(TestLogger testLogger, Class clazz ) {
+        super(testLogger, clazz);
+    }
+
+    protected long getLogCount(Level level, Predicate<LoggingEvent> predicate) {
+        return actual.getLoggingEvents().stream().filter(event -> level.equals(event.getLevel()) && predicate.test(event))
+                .count();
+    }
+
+    protected static Predicate<LoggingEvent> logWithMessage(String message, Object... arguments) {
+        return logWithMessage(message, Optional.empty(), arguments);
+    }
+
+    protected static Predicate<LoggingEvent> logWithMessage(String message, @SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<Throwable> maybeThrowable, Object... arguments) {
+        return event -> message.equals(event.getMessage()) && event.getArguments().equals(Arrays.asList(arguments))
+                && event.getThrowable().equals(maybeThrowable);
+    }
+}

--- a/src/main/java/com/github/valfirst/slf4jtest/Assertions.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/Assertions.java
@@ -1,0 +1,7 @@
+package com.github.valfirst.slf4jtest;
+
+public class Assertions {
+    public static TestLoggerAssert assertThat(TestLogger testLogger) {
+        return new TestLoggerAssert(testLogger);
+    }
+}

--- a/src/main/java/com/github/valfirst/slf4jtest/LevelAssert.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/LevelAssert.java
@@ -1,0 +1,47 @@
+package com.github.valfirst.slf4jtest;
+
+import uk.org.lidalia.slf4jext.Level;
+
+import java.util.Objects;
+
+/**
+ * A set of assertions to validate that logs have been logged to a {@link TestLogger}, for a specific log level.
+ */
+public class LevelAssert extends AbstractTestLoggerAssert<LevelAssert> {
+    private final Level level;
+
+    public LevelAssert(TestLogger logger, Level level) {
+        super(logger, LevelAssert.class);
+
+        this.level = level;
+    }
+
+    /**
+     * Assert that the given log level has the expected number of logs, regardless of content.
+     *
+     * @param expected the number of logs expected at this level
+     * @return a {@link LevelAssert} for chaining
+     */
+    public LevelAssert hasNumberOfLogs(int expected) {
+        long count = getLogCount(level, ignored -> true);
+        if (count != expected) {
+            failWithMessage("Expected level %s to have %d log messages available, but %d were found", level, expected, count);
+        }
+
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        LevelAssert that = (LevelAssert) o;
+        return level == that.level;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), level);
+    }
+}

--- a/src/main/java/com/github/valfirst/slf4jtest/TestLoggerAssert.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLoggerAssert.java
@@ -1,0 +1,104 @@
+package com.github.valfirst.slf4jtest;
+
+import uk.org.lidalia.slf4jext.Level;
+
+import java.util.Optional;
+
+/**
+ * A set of assertions to validate that logs have been logged to a {@link TestLogger}.
+ *
+ * <p>Should be thread safe, as this uses <code>testLogger.getLoggingEvents()</code>.
+ */
+public class TestLoggerAssert extends AbstractTestLoggerAssert<TestLoggerAssert> {
+
+    protected TestLoggerAssert(TestLogger testLogger) {
+        super(testLogger, TestLoggerAssert.class);
+    }
+
+    /**
+     * Verify that a log message, at a specific level, has been logged by the test logger.
+     *
+     * @param level     the level of the log message to look for
+     * @param message   the expected message
+     * @param arguments any optional arguments that may be provided to the log message
+     * @return a {@link TestLoggerAssert} for chaining
+     */
+    public TestLoggerAssert hasLogged(Level level, String message, Object... arguments) {
+        long count = getLogCount(level, logWithMessage(message, arguments));
+        if (count == 0) {
+            if (arguments.length == 0) {
+                failWithMessage("Failed to find %s log with message `%s`", level, message);
+            } else {
+                failWithMessage("Failed to find %s log with message `%s` (with arguments)", level, message);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Verify that a log message, at a specific level, has been logged by the test logger in the presence of a {@link Throwable}.
+     *
+     * @param throwable the throwable that is attached to the log message
+     * @param level     the level of the log message to look for
+     * @param message   the expected message
+     * @param arguments any optional arguments that may be provided to the log message
+     * @return a {@link TestLoggerAssert} for chaining
+     */
+    public TestLoggerAssert hasLogged(Throwable throwable, Level level, String message, Object... arguments) {
+        long count = getLogCount(level, logWithMessage(message, Optional.of(throwable), arguments));
+        if (count == 0) {
+            if (arguments.length == 0) {
+                failWithMessage("Failed to find %s log message with message `%s` (with throwable)", level, message);
+            } else {
+                failWithMessage("Failed to find %s log message with message `%s` (with throwable and arguments)", level, message);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Verify that a log message, at a specific level, has not been logged by the test logger.
+     *
+     * @param level     the level of the log message to look for
+     * @param message   the expected message
+     * @param arguments any optional arguments that may be provided to the log message
+     * @return a {@link TestLoggerAssert} for chaining
+     */
+
+    public TestLoggerAssert hasNotLogged(Level level, String message, Object... arguments) {
+        long count = getLogCount(level, logWithMessage(message, arguments));
+        if (count != 0) {
+            if (arguments.length == 0) {
+                failWithMessage("Found %s log with message `%s`, even though we expected not to", level, message);
+            } else {
+                failWithMessage("Found %s log with message `%s` (with arguments), even though we expected not to", level, message);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Verify that a log message, at a specific level, has not been logged by the test logger in the presence of a {@link Throwable}.
+     *
+     * @param throwable the throwable that is attached to the log message
+     * @param level     the level of the log message to look for
+     * @param message   the expected message
+     * @param arguments any optional arguments that may be provided to the log message
+     * @return a {@link TestLoggerAssert} for chaining
+     */
+    public TestLoggerAssert hasNotLogged(Throwable throwable, Level level, String message, Object... arguments) {
+        long count = getLogCount(level, logWithMessage(message, Optional.of(throwable), arguments));
+        if (count != 0) {
+            if (arguments.length == 0) {
+                failWithMessage("Found %s log with message `%s` (with throwable), even though we expected not to", level, message);
+            } else {
+                failWithMessage("Found %s log with message `%s` (with throwable and arguments), even though we expected not to", level, message);
+            }
+        }
+        return this;
+    }
+
+    public LevelAssert hasLevel(Level level) {
+        return new LevelAssert(actual, level);
+    }
+}

--- a/src/test/java/com/github/valfirst/slf4jtest/AssertionsTest.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/AssertionsTest.java
@@ -1,0 +1,19 @@
+package com.github.valfirst.slf4jtest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class AssertionsTest {
+
+    @Test
+    void canCreateTestLoggerAssert(@Mock TestLogger testLogger) {
+        TestLoggerAssert actual = Assertions.assertThat(testLogger);
+
+        assertThat(actual).isNotNull();
+    }
+}

--- a/src/test/java/com/github/valfirst/slf4jtest/LevelAssertTest.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/LevelAssertTest.java
@@ -1,0 +1,57 @@
+package com.github.valfirst.slf4jtest;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.org.lidalia.slf4jext.Level;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LevelAssertTest {
+
+    @Mock
+    private TestLogger logger;
+
+    private LevelAssert assertions;
+
+    @BeforeEach
+    void setup() {
+        assertions = new LevelAssert(logger, Level.INFO);
+    }
+
+    @Nested
+    class HasLogCount {
+
+        @Test
+        void failsWhenDoesNotMatchExpected() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of());
+
+            assertThatThrownBy(() -> assertions.hasNumberOfLogs(1))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessage("Expected level INFO to have 1 log messages available, but 0 were found");
+        }
+
+        @Test
+        void passesWhenDoesMatch() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Ignore me"), LoggingEvent.info("Yay for me!"), LoggingEvent.info("With args {}", "argument")));
+
+            assertThatCode(() -> assertions.hasNumberOfLogs(2)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void returnsSelfWhenPasses() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.info("Event")));
+
+            LevelAssert actual = assertions.hasNumberOfLogs(1);
+
+            assertThat(actual).isNotNull();
+        }
+    }
+
+}

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
@@ -1,0 +1,230 @@
+package com.github.valfirst.slf4jtest;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.org.lidalia.slf4jext.Level;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestLoggerAssertionsTest {
+
+    @Mock
+    private TestLogger logger;
+
+    private TestLoggerAssert assertions;
+
+    @BeforeEach
+    void setup() {
+        assertions = new TestLoggerAssert(logger);
+    }
+
+    @Nested
+    class HasLogged {
+        @Test
+        void failsWhenLogMessageIsNotFound() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of());
+
+            assertThatThrownBy(() -> assertions.hasLogged(Level.WARN, "Something may be wrong"))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessage("Failed to find WARN log with message `Something may be wrong`");
+        }
+
+        @Test
+        void failsWhenExpectingMoreArgumentsThanExists() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
+
+            assertThatThrownBy(() -> assertions.hasLogged(Level.WARN, "Something may be wrong", "Extra context"))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessage("Failed to find WARN log with message `Something may be wrong` (with arguments)");
+        }
+
+        @Test
+        void failsWhenActuallyMoreArgumentsThanExpected() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong", "Extra context", "Another")));
+
+            assertThatThrownBy(() -> assertions.hasLogged(Level.WARN, "Something may be wrong", "Extra context"))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessage("Failed to find WARN log with message `Something may be wrong` (with arguments)");
+        }
+
+        @Test
+        void failsWhenArgumentsInDifferentOrder() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong", "Another", "Extra context")));
+
+            assertThatThrownBy(() -> assertions.hasLogged(Level.WARN, "Something may be wrong", "Extra context", "Another"))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessage("Failed to find WARN log with message `Something may be wrong` (with arguments)");
+        }
+
+        @Test
+        void passesWhenLogMessageIsFound() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
+
+            assertThatCode(() -> assertions.hasLogged(Level.WARN, "Something may be wrong")).doesNotThrowAnyException();
+        }
+
+        @Test
+        void returnsSelfWhenPasses() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
+
+            TestLoggerAssert actual = assertions.hasLogged(Level.WARN, "Something may be wrong");
+
+            assertThat(actual).isNotNull();
+        }
+
+        @Nested
+        class Throwables {
+            @Mock
+            private Throwable throwable;
+
+            @Test
+            void canBeUsedToAssertWithThrowablesWhenFound() {
+                when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!")));
+
+                assertThatCode(() -> assertions.hasLogged(throwable, Level.ERROR, "There was a problem!")).doesNotThrowAnyException();
+            }
+
+            @Test
+            void canBeUsedToAssertWithThrowablesWhenNotFoundWithArguments() {
+                when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.error("There was a problem!", "context")));
+
+                assertThatThrownBy(() -> assertions.hasLogged(throwable, Level.ERROR, "There was a problem!", "context"))
+                        .isInstanceOf(AssertionError.class)
+                        .hasMessage("Failed to find ERROR log message with message `There was a problem!` (with throwable and arguments)");
+            }
+
+            @Test
+            void canBeUsedToAssertWithThrowablesWhenNotFound() {
+                when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.error("There was a problem!")));
+
+                assertThatThrownBy(() -> assertions.hasLogged(throwable, Level.ERROR, "There was a problem!"))
+                        .isInstanceOf(AssertionError.class)
+                        .hasMessage("Failed to find ERROR log message with message `There was a problem!` (with throwable)");
+            }
+
+
+            @Test
+            void returnsSelfWhenPasses() {
+                when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!")));
+
+                TestLoggerAssert actual = assertions.hasLogged(throwable, Level.ERROR, "There was a problem!");
+
+                assertThat(actual).isNotNull();
+            }
+        }
+    }
+
+    @Nested
+    class HasNotLogged {
+        @Test
+        void failsWhenLogMessageIsFound() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
+
+            assertThatThrownBy(() -> assertions.hasNotLogged(Level.WARN, "Something may be wrong"))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessage("Found WARN log with message `Something may be wrong`, even though we expected not to");
+        }
+
+        @Test
+        void failsWhenExpectingMoreArgumentsThanExists() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
+
+            assertThatCode(() -> assertions.hasNotLogged(Level.WARN, "Something may be wrong", "Extra context")).doesNotThrowAnyException();
+        }
+
+        @Test
+        void passesWhenActuallyMoreArgumentsThanExpected() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong", "Extra context", "Another")));
+
+            assertThatCode(() -> assertions.hasNotLogged(Level.WARN, "Something may be wrong", "Extra context")).doesNotThrowAnyException();
+        }
+
+        @Test
+        void failsWhenArgumentsInDifferentOrder() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong", "Another", "Extra context")));
+
+            assertThatCode(() -> assertions.hasNotLogged(Level.WARN, "Something may be wrong", "Extra context", "Another"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void passesWhenLogMessageIsNotFound() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.info("Nothing to see here")));
+
+            assertThatCode(() -> assertions.hasNotLogged(Level.WARN, "Something may be wrong")).doesNotThrowAnyException();
+        }
+
+        @Test
+        void passesWhenLogMessageIsNotFoundWithArguments() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.info("Nothing to see here", "Context setting")));
+
+            assertThatCode(() -> assertions.hasNotLogged(Level.WARN, "Something may be wrong")).doesNotThrowAnyException();
+        }
+
+        @Test
+        void returnsSelfWhenPasses() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something else")));
+
+            TestLoggerAssert actual = assertions.hasNotLogged(Level.WARN, "Something may be wrong");
+
+            assertThat(actual).isNotNull();
+        }
+
+        @Nested
+        class Throwables {
+            @Mock
+            private Throwable throwable;
+
+            @Test
+            void canBeUsedToAssertWithThrowablesWhenNotFound() {
+                when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem, but this isn't what you're looking for!")));
+
+                assertThatCode(() -> assertions.hasNotLogged(throwable, Level.ERROR, "There was a problem!")).doesNotThrowAnyException();
+            }
+
+            @Test
+            void canBeUsedToAssertWithThrowablesWhenFoundWithArguments() {
+                when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!", "context")));
+
+                assertThatThrownBy(() -> assertions.hasNotLogged(throwable, Level.ERROR, "There was a problem!", "context"))
+                        .isInstanceOf(AssertionError.class)
+                        .hasMessage("Found ERROR log with message `There was a problem!` (with throwable and arguments), even though we expected not to");
+            }
+
+            @Test
+            void canBeUsedToAssertWithThrowablesWhenFound() {
+                when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!")));
+
+                assertThatThrownBy(() -> assertions.hasNotLogged(throwable, Level.ERROR, "There was a problem!"))
+                        .isInstanceOf(AssertionError.class)
+                        .hasMessage("Found ERROR log with message `There was a problem!` (with throwable), even though we expected not to");
+            }
+
+            @Test
+            void returnsSelfWhenPasses() {
+                when(logger.getLoggingEvents()).thenReturn(ImmutableList.of());
+
+                TestLoggerAssert actual = assertions.hasNotLogged(throwable, Level.ERROR, "There was a problem!");
+
+                assertThat(actual).isNotNull();
+            }
+        }
+    }
+
+    @Nested
+    class HasLevel {
+        @Test
+        void returnsLevelAssertRegardlessOfWhetherLogsAreAvailableOrNot() {
+            LevelAssert actual = assertions.hasLevel(Level.ERROR);
+
+            assertThat(actual).isNotNull();
+        }
+    }
+}


### PR DESCRIPTION
As noted in #181, we can provide custom AssertJ assertions as a way to
simplify the ability to write unit tests against this library.

Closes #181.