### PR TITLE
Add assertion for substrings of log messages

### DIFF
--- a/src/main/java/com/github/valfirst/slf4jtest/LevelAssert.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/LevelAssert.java
@@ -3,11 +3,21 @@ package com.github.valfirst.slf4jtest;
 import uk.org.lidalia.slf4jext.Level;
 
 import java.util.Objects;
+import java.util.function.Predicate;
 
 /**
  * A set of assertions to validate that logs have been logged to a {@link TestLogger}, for a specific log level.
  */
 public class LevelAssert extends AbstractTestLoggerAssert<LevelAssert> {
+
+    private static Predicate<LoggingEvent> messageWithSubstring(String substring) {
+        return event -> event.getMessage().contains(substring);
+    }
+
+    private static Predicate<LoggingEvent> messageForPattern(String regex) {
+        return event -> event.getMessage().matches(regex);
+    }
+
     private final Level level;
 
     public LevelAssert(TestLogger logger, Level level) {
@@ -26,6 +36,36 @@ public class LevelAssert extends AbstractTestLoggerAssert<LevelAssert> {
         long count = getLogCount(level, ignored -> true);
         if (count != expected) {
             failWithMessage("Expected level %s to have %d log messages available, but %d were found", level, expected, count);
+        }
+
+        return this;
+    }
+
+    /**
+     * Assert that the given log level includes a log message that contains a substring.
+     *
+     * @param substring a substring of a log message that should be present
+     * @return a {@link LevelAssert} for chaining
+     */
+    public LevelAssert hasMessageContaining(String substring) {
+        long count = getLogCount(level, messageWithSubstring(substring));
+        if (count == 0) {
+            failWithMessage("Expected level %s to contain a log message containing `%s`, but it did not", level, substring);
+        }
+
+        return this;
+    }
+
+    /**
+     * Assert that the given log level includes a log message that matches a regex.
+     *
+     * @param regex the regular expression to which this string is to be matched
+     * @return a {@link LevelAssert} for chaining
+     */
+    public LevelAssert hasMessageMatching(String regex) {
+        long count = getLogCount(level, messageForPattern(regex));
+        if (count == 0) {
+            failWithMessage("Expected level %s to contain a log message matching regex `%s`, but it did not", level, regex);
         }
 
         return this;

--- a/src/test/java/com/github/valfirst/slf4jtest/LevelAssertTest.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/LevelAssertTest.java
@@ -54,4 +54,61 @@ class LevelAssertTest {
         }
     }
 
+    @Nested
+    class HasMessageContaining {
+
+        @Test
+        void failsWhenDoesNotContainSubstring() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of());
+
+            assertThatThrownBy(() -> assertions.hasMessageContaining("words"))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessage("Expected level INFO to contain a log message containing `words`, but it did not");
+        }
+
+        @Test
+        void passesWhenDoesMatch() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Ignore me"), LoggingEvent.info("Yay for me!"), LoggingEvent.info("With args {}", "argument")));
+
+            assertThatCode(() -> assertions.hasMessageContaining("me")).doesNotThrowAnyException();
+        }
+
+        @Test
+        void returnsSelfWhenPasses() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.info("Event")));
+
+            LevelAssert actual = assertions.hasMessageContaining("Event");
+
+            assertThat(actual).isNotNull();
+        }
+    }
+
+    @Nested
+    class HasMessageMatching {
+
+        @Test
+        void failsWhenDoesNotMatchExpected() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.info("")));
+
+            assertThatThrownBy(() -> assertions.hasMessageMatching(".+"))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessage("Expected level INFO to contain a log message matching regex `.+`, but it did not");
+        }
+
+        @Test
+        void passesWhenDoesMatch() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Ignore me"), LoggingEvent.info("Yay for me!"), LoggingEvent.info("With args {}", "argument")));
+
+            assertThatCode(() -> assertions.hasMessageMatching(".* .*")).doesNotThrowAnyException();
+        }
+
+        @Test
+        void returnsSelfWhenPasses() {
+            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.info("12340")));
+
+            LevelAssert actual = assertions.hasMessageMatching("[0-9]+");
+
+            assertThat(actual).isNotNull();
+        }
+    }
 }


### PR DESCRIPTION
If log messages are quite long, or there's data that may be put into
them we can't always predict, it can be useful to only look for a
substring / a regex of the log message.

This makes sense to be under the `LevelAssert` for more fluent
assertions.
