### PR TITLE
Apply Spotless for consistent code formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contribution Guidelines
+
+## Code Formatting
+
+This project uses the [Spotless Maven Plugin](https://github.com/diffplug/spotless/tree/HEAD/plugin-maven) to verify format of our code, as well as auto-format it after changes are made.
+
+You can do this by running:
+
+```sh
+mvn spotless:apply
+```
+
+As part of your local testing, we recommend running the below, to make sure your code is conformant:
+
+```sh
+mvn clean spotless:apply package
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.valfirst</groupId>
     <artifactId>slf4j-test</artifactId>
     <version>2.2.1-SNAPSHOT</version>
 
     <name>SLF4J Test</name>
-    <description>An in-memory SLF4J implementation focused on aiding unit testing.</description>
+    <description>An in-memory SLF4J implementation focused on aiding unit
+        testing.</description>
     <url>https://github.com/valfirst/${project.artifactId}</url>
     <licenses>
         <license>
@@ -234,6 +237,49 @@
                 <configuration>
                     <skip>true</skip>
                     <skipDeploy>true</skipDeploy>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.12.2</version>
+                <configuration>
+                    <java>
+                        <googleJavaFormat>
+                            <version>1.7</version>
+                        </googleJavaFormat>
+                        <trimTrailingWhitespace />
+                        <endWithNewline />
+
+                        <!-- https://github.com/diffplug/spotless/issues/420#issuecomment-512350756 -->
+                        <indent>
+                            <tabs>true</tabs>
+                            <spacesPerTab>2</spacesPerTab>
+                        </indent>
+                        <indent>
+                            <spaces>true</spaces>
+                            <spacesPerTab>4</spacesPerTab>
+                        </indent>
+                    </java>
+
+                    <formats>
+                        <format>
+                            <includes>
+                                <include>pom.xml</include>
+                                <include>src/**/*.xml</include>
+                            </includes>
+
+                            <eclipseWtp>
+                                <type>XML</type>
+                            </eclipseWtp>
+                            <trimTrailingWhitespace />
+                            <endWithNewline />
+                            <indent>
+                                <spaces>true</spaces>
+                                <spacesPerTab>4</spacesPerTab>
+                            </indent>
+                        </format>
+                    </formats>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/github/valfirst/slf4jtest/AbstractTestLoggerAssert.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/AbstractTestLoggerAssert.java
@@ -1,19 +1,20 @@
 package com.github.valfirst.slf4jtest;
 
-import org.assertj.core.api.AbstractAssert;
-import uk.org.lidalia.slf4jext.Level;
-
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Predicate;
+import org.assertj.core.api.AbstractAssert;
+import uk.org.lidalia.slf4jext.Level;
 
-abstract class AbstractTestLoggerAssert<C extends AbstractAssert<C, TestLogger>> extends AbstractAssert<C, TestLogger> {
-    protected AbstractTestLoggerAssert(TestLogger testLogger, Class clazz ) {
+abstract class AbstractTestLoggerAssert<C extends AbstractAssert<C, TestLogger>>
+        extends AbstractAssert<C, TestLogger> {
+    protected AbstractTestLoggerAssert(TestLogger testLogger, Class clazz) {
         super(testLogger, clazz);
     }
 
     protected long getLogCount(Level level, Predicate<LoggingEvent> predicate) {
-        return actual.getLoggingEvents().stream().filter(event -> level.equals(event.getLevel()) && predicate.test(event))
+        return actual.getLoggingEvents().stream()
+                .filter(event -> level.equals(event.getLevel()) && predicate.test(event))
                 .count();
     }
 
@@ -21,8 +22,13 @@ abstract class AbstractTestLoggerAssert<C extends AbstractAssert<C, TestLogger>>
         return logWithMessage(message, Optional.empty(), arguments);
     }
 
-    protected static Predicate<LoggingEvent> logWithMessage(String message, @SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<Throwable> maybeThrowable, Object... arguments) {
-        return event -> message.equals(event.getMessage()) && event.getArguments().equals(Arrays.asList(arguments))
-                && event.getThrowable().equals(maybeThrowable);
+    protected static Predicate<LoggingEvent> logWithMessage(
+            String message,
+            @SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<Throwable> maybeThrowable,
+            Object... arguments) {
+        return event ->
+                message.equals(event.getMessage())
+                        && event.getArguments().equals(Arrays.asList(arguments))
+                        && event.getThrowable().equals(maybeThrowable);
     }
 }

--- a/src/main/java/com/github/valfirst/slf4jtest/LevelAssert.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/LevelAssert.java
@@ -1,13 +1,13 @@
 package com.github.valfirst.slf4jtest;
 
-import uk.org.lidalia.slf4jext.Level;
-
 import java.util.Objects;
 import java.util.function.Predicate;
+import uk.org.lidalia.slf4jext.Level;
 
 /**
- * A set of assertions to validate that logs have been logged to a {@link TestLogger}, for a specific log level.
- */
+* A set of assertions to validate that logs have been logged to a {@link TestLogger}, for a
+* specific log level.
+*/
 public class LevelAssert extends AbstractTestLoggerAssert<LevelAssert> {
 
     private static Predicate<LoggingEvent> messageWithSubstring(String substring) {
@@ -27,45 +27,51 @@ public class LevelAssert extends AbstractTestLoggerAssert<LevelAssert> {
     }
 
     /**
-     * Assert that the given log level has the expected number of logs, regardless of content.
-     *
-     * @param expected the number of logs expected at this level
-     * @return a {@link LevelAssert} for chaining
-     */
+    * Assert that the given log level has the expected number of logs, regardless of content.
+    *
+    * @param expected the number of logs expected at this level
+    * @return a {@link LevelAssert} for chaining
+    */
     public LevelAssert hasNumberOfLogs(int expected) {
         long count = getLogCount(level, ignored -> true);
         if (count != expected) {
-            failWithMessage("Expected level %s to have %d log messages available, but %d were found", level, expected, count);
+            failWithMessage(
+                    "Expected level %s to have %d log messages available, but %d were found",
+                    level, expected, count);
         }
 
         return this;
     }
 
     /**
-     * Assert that the given log level includes a log message that contains a substring.
-     *
-     * @param substring a substring of a log message that should be present
-     * @return a {@link LevelAssert} for chaining
-     */
+    * Assert that the given log level includes a log message that contains a substring.
+    *
+    * @param substring a substring of a log message that should be present
+    * @return a {@link LevelAssert} for chaining
+    */
     public LevelAssert hasMessageContaining(String substring) {
         long count = getLogCount(level, messageWithSubstring(substring));
         if (count == 0) {
-            failWithMessage("Expected level %s to contain a log message containing `%s`, but it did not", level, substring);
+            failWithMessage(
+                    "Expected level %s to contain a log message containing `%s`, but it did not",
+                    level, substring);
         }
 
         return this;
     }
 
     /**
-     * Assert that the given log level includes a log message that matches a regex.
-     *
-     * @param regex the regular expression to which this string is to be matched
-     * @return a {@link LevelAssert} for chaining
-     */
+    * Assert that the given log level includes a log message that matches a regex.
+    *
+    * @param regex the regular expression to which this string is to be matched
+    * @return a {@link LevelAssert} for chaining
+    */
     public LevelAssert hasMessageMatching(String regex) {
         long count = getLogCount(level, messageForPattern(regex));
         if (count == 0) {
-            failWithMessage("Expected level %s to contain a log message matching regex `%s`, but it did not", level, regex);
+            failWithMessage(
+                    "Expected level %s to contain a log message matching regex `%s`, but it did not",
+                    level, regex);
         }
 
         return this;

--- a/src/main/java/com/github/valfirst/slf4jtest/LoggingEvent.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/LoggingEvent.java
@@ -1,5 +1,11 @@
 package com.github.valfirst.slf4jtest;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Optional.empty;
+import static java.util.Optional.ofNullable;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.Collections;
@@ -7,43 +13,32 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
 import org.joda.time.Instant;
 import org.slf4j.Marker;
 import org.slf4j.helpers.MessageFormatter;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
 import uk.org.lidalia.slf4jext.Level;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.Optional.empty;
-import static java.util.Optional.ofNullable;
-
 /**
- * <p>
- * Representation of a call to a logger for test assertion purposes.
- * </p>
- * The contract of {@link #equals(Object)} and {@link #hashCode} is that they compare the results of:
- * <ul>
- * <li>{@link #getLevel()}</li>
- * <li>{@link #getMdc()}</li>
- * <li>{@link #getMarker()}</li>
- * <li>{@link #getThrowable()}</li>
- * <li>{@link #getMessage()}</li>
- * <li>{@link #getArguments()}</li>
- * </ul>
- * <p>
- * They do NOT compare the results of {@link #getTimestamp()} or {@link #getCreatingLogger()} as this would render it impractical
- * to create appropriate expected {@link LoggingEvent}s to compare against.
- * </p>
- * <p>
- * Constructors and convenient static factory methods exist to create {@link LoggingEvent}s with appropriate
- * defaults.  These are not documented further as they should be self-evident.
- * </p>
- */
-@SuppressWarnings({ "PMD.ExcessivePublicCount", "PMD.TooManyMethods" })
+* Representation of a call to a logger for test assertion purposes. The contract of {@link
+* #equals(Object)} and {@link #hashCode} is that they compare the results of:
+*
+* <ul>
+*   <li>{@link #getLevel()}
+*   <li>{@link #getMdc()}
+*   <li>{@link #getMarker()}
+*   <li>{@link #getThrowable()}
+*   <li>{@link #getMessage()}
+*   <li>{@link #getArguments()}
+* </ul>
+*
+* <p>They do NOT compare the results of {@link #getTimestamp()} or {@link #getCreatingLogger()} as
+* this would render it impractical to create appropriate expected {@link LoggingEvent}s to compare
+* against.
+*
+* <p>Constructors and convenient static factory methods exist to create {@link LoggingEvent}s with
+* appropriate defaults. These are not documented further as they should be self-evident.
+*/
+@SuppressWarnings({"PMD.ExcessivePublicCount", "PMD.TooManyMethods"})
 public class LoggingEvent {
 
     private final Level level;
@@ -61,30 +56,42 @@ public class LoggingEvent {
         return new LoggingEvent(Level.TRACE, message, arguments);
     }
 
-    public static LoggingEvent trace(final Throwable throwable, final String message, final Object... arguments) {
+    public static LoggingEvent trace(
+            final Throwable throwable, final String message, final Object... arguments) {
         return new LoggingEvent(Level.TRACE, throwable, message, arguments);
     }
 
-    public static LoggingEvent trace(final Marker marker, final String message, final Object... arguments) {
+    public static LoggingEvent trace(
+            final Marker marker, final String message, final Object... arguments) {
         return new LoggingEvent(Level.TRACE, marker, message, arguments);
     }
 
     public static LoggingEvent trace(
-            final Marker marker, final Throwable throwable, final String message, final Object... arguments) {
+            final Marker marker,
+            final Throwable throwable,
+            final String message,
+            final Object... arguments) {
         return new LoggingEvent(Level.TRACE, marker, throwable, message, arguments);
     }
 
-    public static LoggingEvent trace(final Map<String, String> mdc, final String message, final Object... arguments) {
+    public static LoggingEvent trace(
+            final Map<String, String> mdc, final String message, final Object... arguments) {
         return new LoggingEvent(Level.TRACE, mdc, message, arguments);
     }
 
     public static LoggingEvent trace(
-            final Map<String, String> mdc, final Throwable throwable, final String message, final Object... arguments) {
+            final Map<String, String> mdc,
+            final Throwable throwable,
+            final String message,
+            final Object... arguments) {
         return new LoggingEvent(Level.TRACE, mdc, throwable, message, arguments);
     }
 
     public static LoggingEvent trace(
-            final Map<String, String> mdc, final Marker marker, final String message, final Object... arguments) {
+            final Map<String, String> mdc,
+            final Marker marker,
+            final String message,
+            final Object... arguments) {
         return new LoggingEvent(Level.TRACE, mdc, marker, message, arguments);
     }
 
@@ -101,30 +108,42 @@ public class LoggingEvent {
         return new LoggingEvent(Level.DEBUG, message, arguments);
     }
 
-    public static LoggingEvent debug(final Throwable throwable, final String message, final Object... arguments) {
+    public static LoggingEvent debug(
+            final Throwable throwable, final String message, final Object... arguments) {
         return new LoggingEvent(Level.DEBUG, throwable, message, arguments);
     }
 
-    public static LoggingEvent debug(final Marker marker, final String message, final Object... arguments) {
+    public static LoggingEvent debug(
+            final Marker marker, final String message, final Object... arguments) {
         return new LoggingEvent(Level.DEBUG, marker, message, arguments);
     }
 
     public static LoggingEvent debug(
-            final Marker marker, final Throwable throwable, final String message, final Object... arguments) {
+            final Marker marker,
+            final Throwable throwable,
+            final String message,
+            final Object... arguments) {
         return new LoggingEvent(Level.DEBUG, marker, throwable, message, arguments);
     }
 
-    public static LoggingEvent debug(final Map<String, String> mdc, final String message, final Object... arguments) {
+    public static LoggingEvent debug(
+            final Map<String, String> mdc, final String message, final Object... arguments) {
         return new LoggingEvent(Level.DEBUG, mdc, message, arguments);
     }
 
     public static LoggingEvent debug(
-            final Map<String, String> mdc, final Throwable throwable, final String message, final Object... arguments) {
+            final Map<String, String> mdc,
+            final Throwable throwable,
+            final String message,
+            final Object... arguments) {
         return new LoggingEvent(Level.DEBUG, mdc, throwable, message, arguments);
     }
 
     public static LoggingEvent debug(
-            final Map<String, String> mdc, final Marker marker, final String message, final Object... arguments) {
+            final Map<String, String> mdc,
+            final Marker marker,
+            final String message,
+            final Object... arguments) {
         return new LoggingEvent(Level.DEBUG, mdc, marker, message, arguments);
     }
 
@@ -141,30 +160,42 @@ public class LoggingEvent {
         return new LoggingEvent(Level.INFO, message, arguments);
     }
 
-    public static LoggingEvent info(final Throwable throwable, final String message, final Object... arguments) {
+    public static LoggingEvent info(
+            final Throwable throwable, final String message, final Object... arguments) {
         return new LoggingEvent(Level.INFO, throwable, message, arguments);
     }
 
-    public static LoggingEvent info(final Marker marker, final String message, final Object... arguments) {
+    public static LoggingEvent info(
+            final Marker marker, final String message, final Object... arguments) {
         return new LoggingEvent(Level.INFO, marker, message, arguments);
     }
 
     public static LoggingEvent info(
-            final Marker marker, final Throwable throwable, final String message, final Object... arguments) {
+            final Marker marker,
+            final Throwable throwable,
+            final String message,
+            final Object... arguments) {
         return new LoggingEvent(Level.INFO, marker, throwable, message, arguments);
     }
 
-    public static LoggingEvent info(final Map<String, String> mdc, final String message, final Object... arguments) {
+    public static LoggingEvent info(
+            final Map<String, String> mdc, final String message, final Object... arguments) {
         return new LoggingEvent(Level.INFO, mdc, message, arguments);
     }
 
     public static LoggingEvent info(
-            final Map<String, String> mdc, final Throwable throwable, final String message, final Object... arguments) {
+            final Map<String, String> mdc,
+            final Throwable throwable,
+            final String message,
+            final Object... arguments) {
         return new LoggingEvent(Level.INFO, mdc, throwable, message, arguments);
     }
 
     public static LoggingEvent info(
-            final Map<String, String> mdc, final Marker marker, final String message, final Object... arguments) {
+            final Map<String, String> mdc,
+            final Marker marker,
+            final String message,
+            final Object... arguments) {
         return new LoggingEvent(Level.INFO, mdc, marker, message, arguments);
     }
 
@@ -181,30 +212,42 @@ public class LoggingEvent {
         return new LoggingEvent(Level.WARN, message, arguments);
     }
 
-    public static LoggingEvent warn(final Throwable throwable, final String message, final Object... arguments) {
+    public static LoggingEvent warn(
+            final Throwable throwable, final String message, final Object... arguments) {
         return new LoggingEvent(Level.WARN, throwable, message, arguments);
     }
 
-    public static LoggingEvent warn(final Marker marker, final String message, final Object... arguments) {
+    public static LoggingEvent warn(
+            final Marker marker, final String message, final Object... arguments) {
         return new LoggingEvent(Level.WARN, marker, message, arguments);
     }
 
     public static LoggingEvent warn(
-            final Marker marker, final Throwable throwable, final String message, final Object... arguments) {
+            final Marker marker,
+            final Throwable throwable,
+            final String message,
+            final Object... arguments) {
         return new LoggingEvent(Level.WARN, marker, throwable, message, arguments);
     }
 
-    public static LoggingEvent warn(final Map<String, String> mdc, final String message, final Object... arguments) {
+    public static LoggingEvent warn(
+            final Map<String, String> mdc, final String message, final Object... arguments) {
         return new LoggingEvent(Level.WARN, mdc, message, arguments);
     }
 
     public static LoggingEvent warn(
-            final Map<String, String> mdc, final Throwable throwable, final String message, final Object... arguments) {
+            final Map<String, String> mdc,
+            final Throwable throwable,
+            final String message,
+            final Object... arguments) {
         return new LoggingEvent(Level.WARN, mdc, throwable, message, arguments);
     }
 
     public static LoggingEvent warn(
-            final Map<String, String> mdc, final Marker marker, final String message, final Object... arguments) {
+            final Map<String, String> mdc,
+            final Marker marker,
+            final String message,
+            final Object... arguments) {
         return new LoggingEvent(Level.WARN, mdc, marker, message, arguments);
     }
 
@@ -221,30 +264,42 @@ public class LoggingEvent {
         return new LoggingEvent(Level.ERROR, message, arguments);
     }
 
-    public static LoggingEvent error(final Throwable throwable, final String message, final Object... arguments) {
+    public static LoggingEvent error(
+            final Throwable throwable, final String message, final Object... arguments) {
         return new LoggingEvent(Level.ERROR, throwable, message, arguments);
     }
 
-    public static LoggingEvent error(final Marker marker, final String message, final Object... arguments) {
+    public static LoggingEvent error(
+            final Marker marker, final String message, final Object... arguments) {
         return new LoggingEvent(Level.ERROR, marker, message, arguments);
     }
 
     public static LoggingEvent error(
-            final Marker marker, final Throwable throwable, final String message, final Object... arguments) {
+            final Marker marker,
+            final Throwable throwable,
+            final String message,
+            final Object... arguments) {
         return new LoggingEvent(Level.ERROR, marker, throwable, message, arguments);
     }
 
-    public static LoggingEvent error(final Map<String, String> mdc, final String message, final Object... arguments) {
+    public static LoggingEvent error(
+            final Map<String, String> mdc, final String message, final Object... arguments) {
         return new LoggingEvent(Level.ERROR, mdc, message, arguments);
     }
 
     public static LoggingEvent error(
-            final Map<String, String> mdc, final Throwable throwable, final String message, final Object... arguments) {
+            final Map<String, String> mdc,
+            final Throwable throwable,
+            final String message,
+            final Object... arguments) {
         return new LoggingEvent(Level.ERROR, mdc, throwable, message, arguments);
     }
 
     public static LoggingEvent error(
-            final Map<String, String> mdc, final Marker marker, final String message, final Object... arguments) {
+            final Map<String, String> mdc,
+            final Marker marker,
+            final String message,
+            final Object... arguments) {
         return new LoggingEvent(Level.ERROR, mdc, marker, message, arguments);
     }
 
@@ -261,20 +316,39 @@ public class LoggingEvent {
         this(level, Collections.emptyMap(), empty(), empty(), message, arguments);
     }
 
-    public LoggingEvent(final Level level, final Throwable throwable, final String message, final Object... arguments) {
+    public LoggingEvent(
+            final Level level,
+            final Throwable throwable,
+            final String message,
+            final Object... arguments) {
         this(level, Collections.emptyMap(), empty(), ofNullable(throwable), message, arguments);
     }
 
-    public LoggingEvent(final Level level, final Marker marker, final String message, final Object... arguments) {
+    public LoggingEvent(
+            final Level level, final Marker marker, final String message, final Object... arguments) {
         this(level, Collections.emptyMap(), ofNullable(marker), empty(), message, arguments);
     }
 
     public LoggingEvent(
-            final Level level, final Marker marker, final Throwable throwable, final String message, final Object... arguments) {
-        this(level, Collections.emptyMap(), ofNullable(marker), ofNullable(throwable), message, arguments);
+            final Level level,
+            final Marker marker,
+            final Throwable throwable,
+            final String message,
+            final Object... arguments) {
+        this(
+                level,
+                Collections.emptyMap(),
+                ofNullable(marker),
+                ofNullable(throwable),
+                message,
+                arguments);
     }
 
-    public LoggingEvent(final Level level, final Map<String, String> mdc, final String message, final Object... arguments) {
+    public LoggingEvent(
+            final Level level,
+            final Map<String, String> mdc,
+            final String message,
+            final Object... arguments) {
         this(level, mdc, empty(), empty(), message, arguments);
     }
 
@@ -331,8 +405,11 @@ public class LoggingEvent {
         this.marker = checkNotNull(marker);
         this.throwable = checkNotNull(throwable);
         this.message = checkNotNull(message);
-        this.arguments = ImmutableList.copyOf(Arrays.stream(arguments).map(input -> ofNullable(input).orElse(empty()))
-                .collect(Collectors.toList()));
+        this.arguments =
+                ImmutableList.copyOf(
+                        Arrays.stream(arguments)
+                                .map(input -> ofNullable(input).orElse(empty()))
+                                .collect(Collectors.toList()));
     }
 
     public Level getLevel() {
@@ -360,23 +437,19 @@ public class LoggingEvent {
     }
 
     /**
-     * @return the logger that created this logging event.
-     * @throws IllegalStateException if this logging event was not created by a logger
-     */
+    * @return the logger that created this logging event.
+    * @throws IllegalStateException if this logging event was not created by a logger
+    */
     public TestLogger getCreatingLogger() {
         return creatingLogger.get();
     }
 
-    /**
-     * @return the time at which this logging event was created
-     */
+    /** @return the time at which this logging event was created */
     public Instant getTimestamp() {
         return timestamp;
     }
 
-    /**
-     * @return the name of the thread that created this logging event
-     */
+    /** @return the name of the thread that created this logging event */
     public String getThreadName() {
         return threadName;
     }
@@ -388,7 +461,14 @@ public class LoggingEvent {
     }
 
     private String formatLogStatement() {
-        return getTimestamp() + " [" + getThreadName() + "] " + getLevel() + safeLoggerName() + " - " + getFormattedMessage();
+        return getTimestamp()
+                + " ["
+                + getThreadName()
+                + "] "
+                + getLevel()
+                + safeLoggerName()
+                + " - "
+                + getFormattedMessage();
     }
 
     private String safeLoggerName() {
@@ -418,9 +498,12 @@ public class LoggingEvent {
             return false;
         }
         LoggingEvent that = (LoggingEvent) o;
-        return level == that.level && Objects.equals(mdc, that.mdc) && Objects.equals(marker, that.marker) && Objects
-                .equals(throwable, that.throwable) && Objects.equals(message, that.message) && Objects.equals(arguments,
-                that.arguments);
+        return level == that.level
+                && Objects.equals(mdc, that.mdc)
+                && Objects.equals(marker, that.marker)
+                && Objects.equals(throwable, that.throwable)
+                && Objects.equals(message, that.message)
+                && Objects.equals(arguments, that.arguments);
     }
 
     @Override
@@ -429,9 +512,21 @@ public class LoggingEvent {
     }
 
     @Override
-    public String toString()
-    {
-        return "LoggingEvent{" + "level=" + level + ", mdc=" + mdc + ", marker=" + marker + ", throwable=" + throwable
-                + ", message='" + message + '\'' + ", arguments=" + arguments + '}';
+    public String toString() {
+        return "LoggingEvent{"
+                + "level="
+                + level
+                + ", mdc="
+                + mdc
+                + ", marker="
+                + marker
+                + ", throwable="
+                + throwable
+                + ", message='"
+                + message
+                + '\''
+                + ", arguments="
+                + arguments
+                + '}';
     }
 }

--- a/src/main/java/com/github/valfirst/slf4jtest/OverridableProperties.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/OverridableProperties.java
@@ -2,8 +2,6 @@ package com.github.valfirst.slf4jtest;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
-import java.util.Optional;
 import java.util.Properties;
 
 class OverridableProperties {
@@ -17,8 +15,10 @@ class OverridableProperties {
     }
 
     private Properties getProperties() throws IOException {
-        InputStream resourceAsStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(
-                propertySourceName + ".properties");
+        InputStream resourceAsStream =
+                Thread.currentThread()
+                        .getContextClassLoader()
+                        .getResourceAsStream(propertySourceName + ".properties");
         if (resourceAsStream != null) {
             return loadProperties(resourceAsStream);
         }

--- a/src/main/java/com/github/valfirst/slf4jtest/TestLogger.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLogger.java
@@ -1,23 +1,5 @@
 package com.github.valfirst.slf4jtest;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CopyOnWriteArrayList;
-
-import org.slf4j.Logger;
-import org.slf4j.MDC;
-import org.slf4j.Marker;
-import org.slf4j.helpers.FormattingTuple;
-import org.slf4j.helpers.MessageFormatter;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-
-import uk.org.lidalia.slf4jext.Level;
-
 import static com.google.common.collect.ImmutableList.copyOf;
 import static com.google.common.collect.Sets.immutableEnumSet;
 import static java.util.Arrays.asList;
@@ -29,28 +11,42 @@ import static uk.org.lidalia.slf4jext.Level.INFO;
 import static uk.org.lidalia.slf4jext.Level.TRACE;
 import static uk.org.lidalia.slf4jext.Level.WARN;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.slf4j.Logger;
+import org.slf4j.MDC;
+import org.slf4j.Marker;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MessageFormatter;
+import uk.org.lidalia.slf4jext.Level;
+
 /**
- * <p>
- * Implementation of {@link Logger} which stores {@link LoggingEvent}s in memory and provides methods
- * to access and remove them in order to facilitate writing tests that assert particular logging calls were made.
- * </p>
- * <p>
- * {@link LoggingEvent}s are stored in both an {@link ThreadLocal} and a normal {@link List}. The {@link #getLoggingEvents()}
- * and {@link #clear()} methods reference the {@link ThreadLocal} events. The {@link #getAllLoggingEvents()} and
- * {@link #clearAll()} methods reference all events logged on this Logger.  This is in order to facilitate parallelising
- * tests - tests that use the thread local methods can be parallelised.
- * </p>
- * <p>
- * By default all Levels are enabled.  It is important to note that the conventional hierarchical notion of Levels, where
- * info being enabled implies warn and error being enabled, is not a requirement of the SLF4J API, so the
- * {@link #setEnabledLevels(ImmutableSet)}, {@link #setEnabledLevels(Level...)},
- * {@link #setEnabledLevelsForAllThreads(ImmutableSet)}, {@link #setEnabledLevelsForAllThreads(Level...)} and the various
- * isXxxxxEnabled() methods make no assumptions about this hierarchy.  If you wish to use traditional hierarchical setups you may
- * do so by passing the constants in {@link uk.org.lidalia.slf4jext.ConventionalLevelHierarchy} to
- * {@link #setEnabledLevels(ImmutableSet)} or {@link #setEnabledLevelsForAllThreads(ImmutableSet)}.
- * </p>
- */
-@SuppressWarnings({ "PMD.ExcessivePublicCount", "PMD.TooManyMethods" })
+* Implementation of {@link Logger} which stores {@link LoggingEvent}s in memory and provides
+* methods to access and remove them in order to facilitate writing tests that assert particular
+* logging calls were made.
+*
+* <p>{@link LoggingEvent}s are stored in both an {@link ThreadLocal} and a normal {@link List}. The
+* {@link #getLoggingEvents()} and {@link #clear()} methods reference the {@link ThreadLocal}
+* events. The {@link #getAllLoggingEvents()} and {@link #clearAll()} methods reference all events
+* logged on this Logger. This is in order to facilitate parallelising tests - tests that use the
+* thread local methods can be parallelised.
+*
+* <p>By default all Levels are enabled. It is important to note that the conventional hierarchical
+* notion of Levels, where info being enabled implies warn and error being enabled, is not a
+* requirement of the SLF4J API, so the {@link #setEnabledLevels(ImmutableSet)}, {@link
+* #setEnabledLevels(Level...)}, {@link #setEnabledLevelsForAllThreads(ImmutableSet)}, {@link
+* #setEnabledLevelsForAllThreads(Level...)} and the various isXxxxxEnabled() methods make no
+* assumptions about this hierarchy. If you wish to use traditional hierarchical setups you may do
+* so by passing the constants in {@link uk.org.lidalia.slf4jext.ConventionalLevelHierarchy} to
+* {@link #setEnabledLevels(ImmutableSet)} or {@link #setEnabledLevelsForAllThreads(ImmutableSet)}.
+*/
+@SuppressWarnings({"PMD.ExcessivePublicCount", "PMD.TooManyMethods"})
 public class TestLogger implements Logger {
 
     private final String name;
@@ -58,7 +54,8 @@ public class TestLogger implements Logger {
     private ThreadLocal<List<LoggingEvent>> loggingEvents = ThreadLocal.withInitial(ArrayList::new);
 
     private final List<LoggingEvent> allLoggingEvents = new CopyOnWriteArrayList<>();
-    private volatile ThreadLocal<ImmutableSet<Level>> enabledLevels = ThreadLocal.withInitial(Level::enablableValueSet);
+    private volatile ThreadLocal<ImmutableSet<Level>> enabledLevels =
+            ThreadLocal.withInitial(Level::enablableValueSet);
 
     TestLogger(final String name, final TestLoggerFactory testLoggerFactory) {
         this.name = name;
@@ -70,42 +67,35 @@ public class TestLogger implements Logger {
     }
 
     /**
-     * Removes all {@link LoggingEvent}s logged by this thread and resets the enabled levels of the logger
-     * to {@link Level#enablableValueSet()} for this thread.
-     */
+    * Removes all {@link LoggingEvent}s logged by this thread and resets the enabled levels of the
+    * logger to {@link Level#enablableValueSet()} for this thread.
+    */
     public void clear() {
         loggingEvents.get().clear();
         enabledLevels.remove();
     }
 
     /**
-     * Removes ALL {@link LoggingEvent}s logged on this logger, regardless of thread,
-     * and resets the enabled levels of the logger to {@link Level#enablableValueSet()}
-     * for ALL threads.
-     */
+    * Removes ALL {@link LoggingEvent}s logged on this logger, regardless of thread, and resets the
+    * enabled levels of the logger to {@link Level#enablableValueSet()} for ALL threads.
+    */
     public void clearAll() {
         allLoggingEvents.clear();
         loggingEvents = ThreadLocal.withInitial(ArrayList::new);
         enabledLevels = ThreadLocal.withInitial(Level::enablableValueSet);
     }
 
-    /**
-     * @return all {@link LoggingEvent}s logged on this logger by this thread
-     */
+    /** @return all {@link LoggingEvent}s logged on this logger by this thread */
     public ImmutableList<LoggingEvent> getLoggingEvents() {
         return copyOf(loggingEvents.get());
     }
 
-    /**
-     * @return all {@link LoggingEvent}s logged on this logger by ANY thread
-     */
+    /** @return all {@link LoggingEvent}s logged on this logger by ANY thread */
     public ImmutableList<LoggingEvent> getAllLoggingEvents() {
         return copyOf(allLoggingEvents);
     }
 
-    /**
-     * @return whether this logger is trace enabled in this thread
-     */
+    /** @return whether this logger is trace enabled in this thread */
     @Override
     public boolean isTraceEnabled() {
         return enabledLevels.get().contains(TRACE);
@@ -152,7 +142,8 @@ public class TestLogger implements Logger {
     }
 
     @Override
-    public void trace(final Marker marker, final String format, final Object arg1, final Object arg2) {
+    public void trace(
+            final Marker marker, final String format, final Object arg1, final Object arg2) {
         log(TRACE, marker, format, arg1, arg2);
     }
 
@@ -166,9 +157,7 @@ public class TestLogger implements Logger {
         log(TRACE, marker, msg, throwable);
     }
 
-    /**
-     * @return whether this logger is debug enabled in this thread
-     */
+    /** @return whether this logger is debug enabled in this thread */
     @Override
     public boolean isDebugEnabled() {
         return enabledLevels.get().contains(DEBUG);
@@ -215,7 +204,8 @@ public class TestLogger implements Logger {
     }
 
     @Override
-    public void debug(final Marker marker, final String format, final Object arg1, final Object arg2) {
+    public void debug(
+            final Marker marker, final String format, final Object arg1, final Object arg2) {
         log(DEBUG, marker, format, arg1, arg2);
     }
 
@@ -229,9 +219,7 @@ public class TestLogger implements Logger {
         log(DEBUG, marker, msg, throwable);
     }
 
-    /**
-     * @return whether this logger is info enabled in this thread
-     */
+    /** @return whether this logger is info enabled in this thread */
     @Override
     public boolean isInfoEnabled() {
         return enabledLevels.get().contains(INFO);
@@ -292,9 +280,7 @@ public class TestLogger implements Logger {
         log(INFO, marker, msg, throwable);
     }
 
-    /**
-     * @return whether this logger is warn enabled in this thread
-     */
+    /** @return whether this logger is warn enabled in this thread */
     @Override
     public boolean isWarnEnabled() {
         return enabledLevels.get().contains(WARN);
@@ -355,9 +341,7 @@ public class TestLogger implements Logger {
         log(WARN, marker, msg, throwable);
     }
 
-    /**
-     * @return whether this logger is error enabled in this thread
-     */
+    /** @return whether this logger is error enabled in this thread */
     @Override
     public boolean isErrorEnabled() {
         return enabledLevels.get().contains(ERROR);
@@ -404,7 +388,8 @@ public class TestLogger implements Logger {
     }
 
     @Override
-    public void error(final Marker marker, final String format, final Object arg1, final Object arg2) {
+    public void error(
+            final Marker marker, final String format, final Object arg1, final Object arg2) {
         log(ERROR, marker, format, arg1, arg2);
     }
 
@@ -422,21 +407,32 @@ public class TestLogger implements Logger {
         log(level, format, Optional.empty(), args);
     }
 
-    private void log(final Level level, final String msg, final Throwable throwable) { //NOPMD PMD wrongly thinks unused...
+    private void log(
+            final Level level,
+            final String msg,
+            final Throwable throwable) { // NOPMD PMD wrongly thinks unused...
         addLoggingEvent(level, Optional.empty(), ofNullable(throwable), msg);
     }
 
-    private void log(final Level level, final Marker marker, final String format, final Object... args) {
+    private void log(
+            final Level level, final Marker marker, final String format, final Object... args) {
         log(level, format, ofNullable(marker), args);
     }
 
-    private void log(final Level level, final Marker marker, final String msg, final Throwable throwable) {
+    private void log(
+            final Level level, final Marker marker, final String msg, final Throwable throwable) {
         addLoggingEvent(level, ofNullable(marker), ofNullable(throwable), msg);
     }
 
-    private void log(final Level level, final String format, final Optional<Marker> marker, final Object[] args) {
+    private void log(
+            final Level level, final String format, final Optional<Marker> marker, final Object[] args) {
         final FormattingTuple formattedArgs = MessageFormatter.arrayFormat(format, args);
-        addLoggingEvent(level, marker, ofNullable(formattedArgs.getThrowable()), format, formattedArgs.getArgArray());
+        addLoggingEvent(
+                level,
+                marker,
+                ofNullable(formattedArgs.getThrowable()),
+                format,
+                formattedArgs.getArgArray());
     }
 
     private void addLoggingEvent(
@@ -446,7 +442,8 @@ public class TestLogger implements Logger {
             final String format,
             final Object... args) {
         if (enabledLevels.get().contains(level)) {
-            final LoggingEvent event = new LoggingEvent(of(this), level, mdc(), marker, throwable, format, args);
+            final LoggingEvent event =
+                    new LoggingEvent(of(this), level, mdc(), marker, throwable, format, args);
             allLoggingEvents.add(event);
             loggingEvents.get().add(event);
             testLoggerFactory.addLoggingEvent(event);
@@ -465,59 +462,64 @@ public class TestLogger implements Logger {
         }
     }
 
-    /**
-     * @return the set of levels enabled for this logger on this thread
-     */
+    /** @return the set of levels enabled for this logger on this thread */
     public ImmutableSet<Level> getEnabledLevels() {
         return enabledLevels.get();
     }
 
     /**
-     * The conventional hierarchical notion of Levels, where info being enabled implies warn and error being enabled, is not a
-     * requirement of the SLF4J API, so all levels you wish to enable must be passed explicitly to this method.  If you wish to
-     * use traditional hierarchical setups you may conveniently do so by using the constants in
-     * {@link uk.org.lidalia.slf4jext.ConventionalLevelHierarchy}
-     *
-     * @param enabledLevels levels which will be considered enabled for this logger IN THIS THREAD;
-     *                      does not affect enabled levels for this logger in other threads
-     */
+    * The conventional hierarchical notion of Levels, where info being enabled implies warn and error
+    * being enabled, is not a requirement of the SLF4J API, so all levels you wish to enable must be
+    * passed explicitly to this method. If you wish to use traditional hierarchical setups you may
+    * conveniently do so by using the constants in {@link
+    * uk.org.lidalia.slf4jext.ConventionalLevelHierarchy}
+    *
+    * @param enabledLevels levels which will be considered enabled for this logger IN THIS THREAD;
+    *     does not affect enabled levels for this logger in other threads
+    */
     public void setEnabledLevels(final ImmutableSet<Level> enabledLevels) {
         this.enabledLevels.set(enabledLevels);
     }
 
     /**
-     * The conventional hierarchical notion of Levels, where info being enabled implies warn and error being enabled, is not a
-     * requirement of the SLF4J API, so all levels you wish to enable must be passed explicitly to this method.  If you wish to
-     * use traditional hierarchical setups you may conveniently do so by passing the constants in
-     * {@link uk.org.lidalia.slf4jext.ConventionalLevelHierarchy} to {@link #setEnabledLevels(ImmutableSet)}
-     *
-     * @param enabledLevels levels which will be considered enabled for this logger IN THIS THREAD;
-     *                      does not affect enabled levels for this logger in other threads
-     */
+    * The conventional hierarchical notion of Levels, where info being enabled implies warn and error
+    * being enabled, is not a requirement of the SLF4J API, so all levels you wish to enable must be
+    * passed explicitly to this method. If you wish to use traditional hierarchical setups you may
+    * conveniently do so by passing the constants in {@link
+    * uk.org.lidalia.slf4jext.ConventionalLevelHierarchy} to {@link #setEnabledLevels(ImmutableSet)}
+    *
+    * @param enabledLevels levels which will be considered enabled for this logger IN THIS THREAD;
+    *     does not affect enabled levels for this logger in other threads
+    */
     public void setEnabledLevels(final Level... enabledLevels) {
         setEnabledLevels(immutableEnumSet(asList(enabledLevels)));
     }
 
     /**
-     * The conventional hierarchical notion of Levels, where info being enabled implies warn and error being enabled, is not a
-     * requirement of the SLF4J API, so all levels you wish to enable must be passed explicitly to this method.  If you wish to
-     * use traditional hierarchical setups you may conveniently do so by using the constants in
-     * {@link uk.org.lidalia.slf4jext.ConventionalLevelHierarchy}
-     *
-     * @param enabledLevelsForAllThreads levels which will be considered enabled for this logger IN ALL THREADS
-     */
+    * The conventional hierarchical notion of Levels, where info being enabled implies warn and error
+    * being enabled, is not a requirement of the SLF4J API, so all levels you wish to enable must be
+    * passed explicitly to this method. If you wish to use traditional hierarchical setups you may
+    * conveniently do so by using the constants in {@link
+    * uk.org.lidalia.slf4jext.ConventionalLevelHierarchy}
+    *
+    * @param enabledLevelsForAllThreads levels which will be considered enabled for this logger IN
+    *     ALL THREADS
+    */
     public void setEnabledLevelsForAllThreads(final ImmutableSet<Level> enabledLevelsForAllThreads) {
         this.enabledLevels = ThreadLocal.withInitial(() -> enabledLevelsForAllThreads);
     }
 
     /**
-     * The conventional hierarchical notion of Levels, where info being enabled implies warn and error being enabled, is not a
-     * requirement of the SLF4J API, so all levels you wish to enable must be passed explicitly to this method.  If you wish to
-     * use traditional hierarchical setups you may conveniently do so by passing the constants in
-     * {@link uk.org.lidalia.slf4jext.ConventionalLevelHierarchy} to {@link #setEnabledLevelsForAllThreads(ImmutableSet)}
-     *
-     * @param enabledLevelsForAllThreads levels which will be considered enabled for this logger IN ALL THREADS
-     */
+    * The conventional hierarchical notion of Levels, where info being enabled implies warn and error
+    * being enabled, is not a requirement of the SLF4J API, so all levels you wish to enable must be
+    * passed explicitly to this method. If you wish to use traditional hierarchical setups you may
+    * conveniently do so by passing the constants in {@link
+    * uk.org.lidalia.slf4jext.ConventionalLevelHierarchy} to {@link
+    * #setEnabledLevelsForAllThreads(ImmutableSet)}
+    *
+    * @param enabledLevelsForAllThreads levels which will be considered enabled for this logger IN
+    *     ALL THREADS
+    */
     public void setEnabledLevelsForAllThreads(final Level... enabledLevelsForAllThreads) {
         setEnabledLevelsForAllThreads(ImmutableSet.copyOf(enabledLevelsForAllThreads));
     }

--- a/src/main/java/com/github/valfirst/slf4jtest/TestLoggerAssert.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLoggerAssert.java
@@ -1,14 +1,13 @@
 package com.github.valfirst.slf4jtest;
 
+import java.util.Optional;
 import uk.org.lidalia.slf4jext.Level;
 
-import java.util.Optional;
-
 /**
- * A set of assertions to validate that logs have been logged to a {@link TestLogger}.
- *
- * <p>Should be thread safe, as this uses <code>testLogger.getLoggingEvents()</code>.
- */
+* A set of assertions to validate that logs have been logged to a {@link TestLogger}.
+*
+* <p>Should be thread safe, as this uses <code>testLogger.getLoggingEvents()</code>.
+*/
 public class TestLoggerAssert extends AbstractTestLoggerAssert<TestLoggerAssert> {
 
     protected TestLoggerAssert(TestLogger testLogger) {
@@ -16,13 +15,13 @@ public class TestLoggerAssert extends AbstractTestLoggerAssert<TestLoggerAssert>
     }
 
     /**
-     * Verify that a log message, at a specific level, has been logged by the test logger.
-     *
-     * @param level     the level of the log message to look for
-     * @param message   the expected message
-     * @param arguments any optional arguments that may be provided to the log message
-     * @return a {@link TestLoggerAssert} for chaining
-     */
+    * Verify that a log message, at a specific level, has been logged by the test logger.
+    *
+    * @param level the level of the log message to look for
+    * @param message the expected message
+    * @param arguments any optional arguments that may be provided to the log message
+    * @return a {@link TestLoggerAssert} for chaining
+    */
     public TestLoggerAssert hasLogged(Level level, String message, Object... arguments) {
         long count = getLogCount(level, logWithMessage(message, arguments));
         if (count == 0) {
@@ -36,63 +35,76 @@ public class TestLoggerAssert extends AbstractTestLoggerAssert<TestLoggerAssert>
     }
 
     /**
-     * Verify that a log message, at a specific level, has been logged by the test logger in the presence of a {@link Throwable}.
-     *
-     * @param throwable the throwable that is attached to the log message
-     * @param level     the level of the log message to look for
-     * @param message   the expected message
-     * @param arguments any optional arguments that may be provided to the log message
-     * @return a {@link TestLoggerAssert} for chaining
-     */
-    public TestLoggerAssert hasLogged(Throwable throwable, Level level, String message, Object... arguments) {
+    * Verify that a log message, at a specific level, has been logged by the test logger in the
+    * presence of a {@link Throwable}.
+    *
+    * @param throwable the throwable that is attached to the log message
+    * @param level the level of the log message to look for
+    * @param message the expected message
+    * @param arguments any optional arguments that may be provided to the log message
+    * @return a {@link TestLoggerAssert} for chaining
+    */
+    public TestLoggerAssert hasLogged(
+            Throwable throwable, Level level, String message, Object... arguments) {
         long count = getLogCount(level, logWithMessage(message, Optional.of(throwable), arguments));
         if (count == 0) {
             if (arguments.length == 0) {
-                failWithMessage("Failed to find %s log message with message `%s` (with throwable)", level, message);
+                failWithMessage(
+                        "Failed to find %s log message with message `%s` (with throwable)", level, message);
             } else {
-                failWithMessage("Failed to find %s log message with message `%s` (with throwable and arguments)", level, message);
+                failWithMessage(
+                        "Failed to find %s log message with message `%s` (with throwable and arguments)",
+                        level, message);
             }
         }
         return this;
     }
 
     /**
-     * Verify that a log message, at a specific level, has not been logged by the test logger.
-     *
-     * @param level     the level of the log message to look for
-     * @param message   the expected message
-     * @param arguments any optional arguments that may be provided to the log message
-     * @return a {@link TestLoggerAssert} for chaining
-     */
-
+    * Verify that a log message, at a specific level, has not been logged by the test logger.
+    *
+    * @param level the level of the log message to look for
+    * @param message the expected message
+    * @param arguments any optional arguments that may be provided to the log message
+    * @return a {@link TestLoggerAssert} for chaining
+    */
     public TestLoggerAssert hasNotLogged(Level level, String message, Object... arguments) {
         long count = getLogCount(level, logWithMessage(message, arguments));
         if (count != 0) {
             if (arguments.length == 0) {
-                failWithMessage("Found %s log with message `%s`, even though we expected not to", level, message);
+                failWithMessage(
+                        "Found %s log with message `%s`, even though we expected not to", level, message);
             } else {
-                failWithMessage("Found %s log with message `%s` (with arguments), even though we expected not to", level, message);
+                failWithMessage(
+                        "Found %s log with message `%s` (with arguments), even though we expected not to",
+                        level, message);
             }
         }
         return this;
     }
 
     /**
-     * Verify that a log message, at a specific level, has not been logged by the test logger in the presence of a {@link Throwable}.
-     *
-     * @param throwable the throwable that is attached to the log message
-     * @param level     the level of the log message to look for
-     * @param message   the expected message
-     * @param arguments any optional arguments that may be provided to the log message
-     * @return a {@link TestLoggerAssert} for chaining
-     */
-    public TestLoggerAssert hasNotLogged(Throwable throwable, Level level, String message, Object... arguments) {
+    * Verify that a log message, at a specific level, has not been logged by the test logger in the
+    * presence of a {@link Throwable}.
+    *
+    * @param throwable the throwable that is attached to the log message
+    * @param level the level of the log message to look for
+    * @param message the expected message
+    * @param arguments any optional arguments that may be provided to the log message
+    * @return a {@link TestLoggerAssert} for chaining
+    */
+    public TestLoggerAssert hasNotLogged(
+            Throwable throwable, Level level, String message, Object... arguments) {
         long count = getLogCount(level, logWithMessage(message, Optional.of(throwable), arguments));
         if (count != 0) {
             if (arguments.length == 0) {
-                failWithMessage("Found %s log with message `%s` (with throwable), even though we expected not to", level, message);
+                failWithMessage(
+                        "Found %s log with message `%s` (with throwable), even though we expected not to",
+                        level, message);
             } else {
-                failWithMessage("Found %s log with message `%s` (with throwable and arguments), even though we expected not to", level, message);
+                failWithMessage(
+                        "Found %s log with message `%s` (with throwable and arguments), even though we expected not to",
+                        level, message);
             }
         }
         return this;

--- a/src/main/java/com/github/valfirst/slf4jtest/TestLoggerFactory.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLoggerFactory.java
@@ -1,5 +1,10 @@
 package com.github.valfirst.slf4jtest;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
@@ -10,34 +15,31 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
-
 import org.slf4j.ILoggerFactory;
-
-import com.google.common.base.Suppliers;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
 import uk.org.lidalia.slf4jext.Level;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class TestLoggerFactory implements ILoggerFactory {
 
-    private static final Supplier<TestLoggerFactory> INSTANCE = Suppliers.memoize(() -> {
-        try {
-            final String level = new OverridableProperties("slf4jtest").getProperty("print.level", "OFF");
-            return new TestLoggerFactory(Level.valueOf(level));
-        } catch (IllegalArgumentException e) {
-            throw new IllegalStateException("Invalid level name in property print.level of file slf4jtest.properties " +
-                    "or System property slf4jtest.print.level", e);
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    });
+    private static final Supplier<TestLoggerFactory> INSTANCE =
+            Suppliers.memoize(
+                    () -> {
+                        try {
+                            final String level =
+                                    new OverridableProperties("slf4jtest").getProperty("print.level", "OFF");
+                            return new TestLoggerFactory(Level.valueOf(level));
+                        } catch (IllegalArgumentException e) {
+                            throw new IllegalStateException(
+                                    "Invalid level name in property print.level of file slf4jtest.properties "
+                                            + "or System property slf4jtest.print.level",
+                                    e);
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    });
 
     private final ConcurrentMap<String, TestLogger> loggers = new ConcurrentHashMap<>();
-    private final List<LoggingEvent> allLoggingEvents = Collections.synchronizedList(new ArrayList<>());
+    private final List<LoggingEvent> allLoggingEvents =
+            Collections.synchronizedList(new ArrayList<>());
     private ThreadLocal<List<LoggingEvent>> loggingEvents = ThreadLocal.withInitial(ArrayList::new);
     private volatile Level printLevel;
 
@@ -103,14 +105,14 @@ public final class TestLoggerFactory implements ILoggerFactory {
     }
 
     public void clearLoggers() {
-        for (final TestLogger testLogger: loggers.values()) {
+        for (final TestLogger testLogger : loggers.values()) {
             testLogger.clear();
         }
         loggingEvents.get().clear();
     }
 
     public void clearAllLoggers() {
-        for (final TestLogger testLogger: loggers.values()) {
+        for (final TestLogger testLogger : loggers.values()) {
             testLogger.clearAll();
         }
         loggingEvents = ThreadLocal.withInitial(ArrayList::new);

--- a/src/main/java/com/github/valfirst/slf4jtest/TestLoggerFactoryExtension.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLoggerFactoryExtension.java
@@ -3,9 +3,7 @@ package com.github.valfirst.slf4jtest;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-/**
- * @author Valery Yatsynovich
- */
+/** @author Valery Yatsynovich */
 public class TestLoggerFactoryExtension implements BeforeTestExecutionCallback {
 
     @Override

--- a/src/main/java/com/github/valfirst/slf4jtest/TestLoggerFactoryResetRule.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLoggerFactoryResetRule.java
@@ -5,9 +5,9 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 /**
- * A <a href="https://github.com/junit-team/junit/wiki">JUnit</a> rule that clears the ThreadLocal state of all the TestLoggers
- * and the TestLoggerFactory.
- */
+* A <a href="https://github.com/junit-team/junit/wiki">JUnit</a> rule that clears the ThreadLocal
+* state of all the TestLoggers and the TestLoggerFactory.
+*/
 public class TestLoggerFactoryResetRule implements TestRule {
 
     @Override

--- a/src/main/java/com/github/valfirst/slf4jtest/TestMDCAdapter.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestMDCAdapter.java
@@ -1,11 +1,9 @@
 package com.github.valfirst.slf4jtest;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.slf4j.spi.MDCAdapter;
-
-import com.google.common.collect.ImmutableMap;
 
 public class TestMDCAdapter implements MDCAdapter {
 

--- a/src/main/java/com/github/valfirst/slf4jtest/TestSLF4JServiceProvider.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestSLF4JServiceProvider.java
@@ -6,11 +6,8 @@ import org.slf4j.helpers.BasicMarkerFactory;
 import org.slf4j.spi.MDCAdapter;
 import org.slf4j.spi.SLF4JServiceProvider;
 
-/**
- * @author Valery Yatsynovich
- */
-public class TestSLF4JServiceProvider implements SLF4JServiceProvider
-{
+/** @author Valery Yatsynovich */
+public class TestSLF4JServiceProvider implements SLF4JServiceProvider {
     public static final String REQUESTED_API_VERSION = "1.8.99";
 
     private ILoggerFactory loggerFactory;
@@ -25,26 +22,22 @@ public class TestSLF4JServiceProvider implements SLF4JServiceProvider
     }
 
     @Override
-    public ILoggerFactory getLoggerFactory()
-    {
+    public ILoggerFactory getLoggerFactory() {
         return loggerFactory;
     }
 
     @Override
-    public IMarkerFactory getMarkerFactory()
-    {
+    public IMarkerFactory getMarkerFactory() {
         return markerFactory;
     }
 
     @Override
-    public MDCAdapter getMDCAdapter()
-    {
+    public MDCAdapter getMDCAdapter() {
         return mdcAdapter;
     }
 
     @Override
-    public String getRequesteApiVersion()
-    {
+    public String getRequesteApiVersion() {
         return REQUESTED_API_VERSION;
     }
 }

--- a/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -1,9 +1,8 @@
 package org.slf4j.impl;
 
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.spi.LoggerFactoryBinder;
-
-import com.github.valfirst.slf4jtest.TestLoggerFactory;
 
 public final class StaticLoggerBinder implements LoggerFactoryBinder {
 
@@ -15,7 +14,7 @@ public final class StaticLoggerBinder implements LoggerFactoryBinder {
         return SINGLETON;
     }
 
-    private StaticLoggerBinder() { }
+    private StaticLoggerBinder() {}
 
     public ILoggerFactory getLoggerFactory() {
         return TestLoggerFactory.getInstance();

--- a/src/main/java/org/slf4j/impl/StaticMDCBinder.java
+++ b/src/main/java/org/slf4j/impl/StaticMDCBinder.java
@@ -1,8 +1,7 @@
 package org.slf4j.impl;
 
-import org.slf4j.spi.MDCAdapter;
-
 import com.github.valfirst.slf4jtest.TestMDCAdapter;
+import org.slf4j.spi.MDCAdapter;
 
 public final class StaticMDCBinder {
 
@@ -10,8 +9,7 @@ public final class StaticMDCBinder {
 
     private final TestMDCAdapter testMDCAdapter = new TestMDCAdapter();
 
-    private StaticMDCBinder() {
-    }
+    private StaticMDCBinder() {}
 
     public MDCAdapter getMDCA() {
         return testMDCAdapter;

--- a/src/main/java/org/slf4j/impl/StaticMarkerBinder.java
+++ b/src/main/java/org/slf4j/impl/StaticMarkerBinder.java
@@ -10,7 +10,7 @@ public final class StaticMarkerBinder implements MarkerFactoryBinder {
 
     private final IMarkerFactory markerFactory = new BasicMarkerFactory();
 
-    private StaticMarkerBinder() { }
+    private StaticMarkerBinder() {}
 
     public IMarkerFactory getMarkerFactory() {
         return markerFactory;

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <project>
 
-  <googleAnalyticsAccountId>UA-15938495-2</googleAnalyticsAccountId>
+    <googleAnalyticsAccountId>UA-15938495-2</googleAnalyticsAccountId>
 
-  <skin>
-    <groupId>org.apache.maven.skins</groupId>
-    <artifactId>maven-fluido-skin</artifactId>
-    <version>1.7</version>
-  </skin>
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>1.7</version>
+    </skin>
 
-  <body>
-    <head>
+    <body>
+        <head>
       <![CDATA[<script type="text/javascript">
         $(document).ready(function () {
           $(".source").addClass("prettyprint");
@@ -18,26 +18,26 @@
         });
       </script>
       ]]>
-    </head>
-    <menu name="Overview">
-      <item name="Introduction" href="index.html" />
-      <item name="Usage" href="usage.html" />
-      <item name="Changelog" href="changelog.html" />
-    </menu>
-    <menu name="Previous Versions">
-      <item name="1.0.1" href="site-versions/1.0.1/"/>
-      <item name="1.0.0" href="site-versions/1.0.0/"/>
-    </menu>
-    <menu ref="reports"/>
-  </body>
+        </head>
+        <menu name="Overview">
+            <item name="Introduction" href="index.html" />
+            <item name="Usage" href="usage.html" />
+            <item name="Changelog" href="changelog.html" />
+        </menu>
+        <menu name="Previous Versions">
+            <item name="1.0.1" href="site-versions/1.0.1/" />
+            <item name="1.0.0" href="site-versions/1.0.0/" />
+        </menu>
+        <menu ref="reports" />
+    </body>
 
-  <custom>
-    <fluidoSkin>
-      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
-      <gitHub>
-        <projectId>valfirst/${project.artifactId}</projectId>
-        <ribbonOrientation>right</ribbonOrientation>
-      </gitHub>
-    </fluidoSkin>
-  </custom>
+    <custom>
+        <fluidoSkin>
+            <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+            <gitHub>
+                <projectId>valfirst/${project.artifactId}</projectId>
+                <ribbonOrientation>right</ribbonOrientation>
+            </gitHub>
+        </fluidoSkin>
+    </custom>
 </project>

--- a/src/test/java/com/github/valfirst/slf4jtest/AssertionsTest.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/AssertionsTest.java
@@ -1,11 +1,11 @@
 package com.github.valfirst.slf4jtest;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 class AssertionsTest {

--- a/src/test/java/com/github/valfirst/slf4jtest/LevelAssertTest.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/LevelAssertTest.java
@@ -1,5 +1,8 @@
 package com.github.valfirst.slf4jtest;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -9,14 +12,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.org.lidalia.slf4jext.Level;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.when;
-
 @ExtendWith(MockitoExtension.class)
 class LevelAssertTest {
 
-    @Mock
-    private TestLogger logger;
+    @Mock private TestLogger logger;
 
     private LevelAssert assertions;
 
@@ -39,7 +38,12 @@ class LevelAssertTest {
 
         @Test
         void passesWhenDoesMatch() {
-            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Ignore me"), LoggingEvent.info("Yay for me!"), LoggingEvent.info("With args {}", "argument")));
+            when(logger.getLoggingEvents())
+                    .thenReturn(
+                            ImmutableList.of(
+                                    LoggingEvent.warn("Ignore me"),
+                                    LoggingEvent.info("Yay for me!"),
+                                    LoggingEvent.info("With args {}", "argument")));
 
             assertThatCode(() -> assertions.hasNumberOfLogs(2)).doesNotThrowAnyException();
         }
@@ -63,12 +67,18 @@ class LevelAssertTest {
 
             assertThatThrownBy(() -> assertions.hasMessageContaining("words"))
                     .isInstanceOf(AssertionError.class)
-                    .hasMessage("Expected level INFO to contain a log message containing `words`, but it did not");
+                    .hasMessage(
+                            "Expected level INFO to contain a log message containing `words`, but it did not");
         }
 
         @Test
         void passesWhenDoesMatch() {
-            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Ignore me"), LoggingEvent.info("Yay for me!"), LoggingEvent.info("With args {}", "argument")));
+            when(logger.getLoggingEvents())
+                    .thenReturn(
+                            ImmutableList.of(
+                                    LoggingEvent.warn("Ignore me"),
+                                    LoggingEvent.info("Yay for me!"),
+                                    LoggingEvent.info("With args {}", "argument")));
 
             assertThatCode(() -> assertions.hasMessageContaining("me")).doesNotThrowAnyException();
         }
@@ -92,12 +102,18 @@ class LevelAssertTest {
 
             assertThatThrownBy(() -> assertions.hasMessageMatching(".+"))
                     .isInstanceOf(AssertionError.class)
-                    .hasMessage("Expected level INFO to contain a log message matching regex `.+`, but it did not");
+                    .hasMessage(
+                            "Expected level INFO to contain a log message matching regex `.+`, but it did not");
         }
 
         @Test
         void passesWhenDoesMatch() {
-            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Ignore me"), LoggingEvent.info("Yay for me!"), LoggingEvent.info("With args {}", "argument")));
+            when(logger.getLoggingEvents())
+                    .thenReturn(
+                            ImmutableList.of(
+                                    LoggingEvent.warn("Ignore me"),
+                                    LoggingEvent.info("Yay for me!"),
+                                    LoggingEvent.info("With args {}", "argument")));
 
             assertThatCode(() -> assertions.hasMessageMatching(".* .*")).doesNotThrowAnyException();
         }

--- a/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
@@ -1,31 +1,7 @@
 package com.github.valfirst.slf4jtest;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.function.BiFunction;
-import java.util.stream.Stream;
-
-import org.joda.time.DateTimeUtils;
-import org.joda.time.Instant;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.slf4j.Marker;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
-import uk.org.lidalia.slf4jext.Level;
-
-import static com.github.valfirst.slf4jtest.LoggingEvent.error;
 import static com.github.valfirst.slf4jtest.LoggingEvent.debug;
+import static com.github.valfirst.slf4jtest.LoggingEvent.error;
 import static com.github.valfirst.slf4jtest.LoggingEvent.info;
 import static com.github.valfirst.slf4jtest.LoggingEvent.trace;
 import static com.github.valfirst.slf4jtest.LoggingEvent.warn;
@@ -47,6 +23,27 @@ import static uk.org.lidalia.slf4jext.Level.INFO;
 import static uk.org.lidalia.slf4jext.Level.TRACE;
 import static uk.org.lidalia.slf4jext.Level.WARN;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.Instant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Marker;
+import uk.org.lidalia.slf4jext.Level;
+
 class LoggingEventTests extends StdIoTests {
 
     private static final ImmutableMap<String, String> emptyMap = ImmutableMap.of();
@@ -61,8 +58,7 @@ class LoggingEventTests extends StdIoTests {
     private final List<Object> args = asList(arg1, arg2);
 
     @AfterEach
-    void afterEach()
-    {
+    void afterEach() {
         super.after();
         DateTimeUtils.setCurrentMillisSystem();
         TestLoggerFactory.reset();
@@ -158,12 +154,11 @@ class LoggingEventTests extends StdIoTests {
 
     static Stream<Arguments> messageArgs() {
         return Stream.of(
-            arguments((BiFunction<String, Object[], LoggingEvent>) LoggingEvent::trace, TRACE),
-            arguments((BiFunction<String, Object[], LoggingEvent>) LoggingEvent::debug, DEBUG),
-            arguments((BiFunction<String, Object[], LoggingEvent>) LoggingEvent::info,  INFO),
-            arguments((BiFunction<String, Object[], LoggingEvent>) LoggingEvent::warn,  WARN),
-            arguments((BiFunction<String, Object[], LoggingEvent>) LoggingEvent::error, ERROR)
-        );
+                arguments((BiFunction<String, Object[], LoggingEvent>) LoggingEvent::trace, TRACE),
+                arguments((BiFunction<String, Object[], LoggingEvent>) LoggingEvent::debug, DEBUG),
+                arguments((BiFunction<String, Object[], LoggingEvent>) LoggingEvent::info, INFO),
+                arguments((BiFunction<String, Object[], LoggingEvent>) LoggingEvent::warn, WARN),
+                arguments((BiFunction<String, Object[], LoggingEvent>) LoggingEvent::error, ERROR));
     }
 
     @ParameterizedTest
@@ -176,17 +171,22 @@ class LoggingEventTests extends StdIoTests {
 
     static Stream<Arguments> throwableMessageArgs() {
         return Stream.of(
-            arguments((TriFunction<Throwable, String, Object[], LoggingEvent>) LoggingEvent::trace, TRACE),
-            arguments((TriFunction<Throwable, String, Object[], LoggingEvent>) LoggingEvent::debug, DEBUG),
-            arguments((TriFunction<Throwable, String, Object[], LoggingEvent>) LoggingEvent::info,  INFO),
-            arguments((TriFunction<Throwable, String, Object[], LoggingEvent>) LoggingEvent::warn,  WARN),
-            arguments((TriFunction<Throwable, String, Object[], LoggingEvent>) LoggingEvent::error, ERROR)
-        );
+                arguments(
+                        (TriFunction<Throwable, String, Object[], LoggingEvent>) LoggingEvent::trace, TRACE),
+                arguments(
+                        (TriFunction<Throwable, String, Object[], LoggingEvent>) LoggingEvent::debug, DEBUG),
+                arguments(
+                        (TriFunction<Throwable, String, Object[], LoggingEvent>) LoggingEvent::info, INFO),
+                arguments(
+                        (TriFunction<Throwable, String, Object[], LoggingEvent>) LoggingEvent::warn, WARN),
+                arguments(
+                        (TriFunction<Throwable, String, Object[], LoggingEvent>) LoggingEvent::error, ERROR));
     }
 
     @ParameterizedTest
     @MethodSource("throwableMessageArgs")
-    void throwableMessageArgs(TriFunction<Throwable, String, Object[], LoggingEvent> producer, Level level) {
+    void throwableMessageArgs(
+            TriFunction<Throwable, String, Object[], LoggingEvent> producer, Level level) {
         LoggingEvent event = producer.apply(throwable, message, new Object[] {arg1, arg2});
         LoggingEvent expected = new LoggingEvent(level, throwable, message, arg1, arg2);
         assertThat(event, is(expected));
@@ -194,17 +194,18 @@ class LoggingEventTests extends StdIoTests {
 
     static Stream<Arguments> markerMessageArgs() {
         return Stream.of(
-            arguments((TriFunction<Marker, String, Object[], LoggingEvent>) LoggingEvent::trace, TRACE),
-            arguments((TriFunction<Marker, String, Object[], LoggingEvent>) LoggingEvent::debug, DEBUG),
-            arguments((TriFunction<Marker, String, Object[], LoggingEvent>) LoggingEvent::info,  INFO),
-            arguments((TriFunction<Marker, String, Object[], LoggingEvent>) LoggingEvent::warn,  WARN),
-            arguments((TriFunction<Marker, String, Object[], LoggingEvent>) LoggingEvent::error, ERROR)
-        );
+                arguments((TriFunction<Marker, String, Object[], LoggingEvent>) LoggingEvent::trace, TRACE),
+                arguments((TriFunction<Marker, String, Object[], LoggingEvent>) LoggingEvent::debug, DEBUG),
+                arguments((TriFunction<Marker, String, Object[], LoggingEvent>) LoggingEvent::info, INFO),
+                arguments((TriFunction<Marker, String, Object[], LoggingEvent>) LoggingEvent::warn, WARN),
+                arguments(
+                        (TriFunction<Marker, String, Object[], LoggingEvent>) LoggingEvent::error, ERROR));
     }
 
     @ParameterizedTest
     @MethodSource("markerMessageArgs")
-    void markerMessageArgs(TriFunction<Marker, String, Object[], LoggingEvent> producer, Level level) {
+    void markerMessageArgs(
+            TriFunction<Marker, String, Object[], LoggingEvent> producer, Level level) {
         LoggingEvent event = producer.apply(marker, message, new Object[] {arg1, arg2});
         LoggingEvent expected = new LoggingEvent(level, marker, message, arg1, arg2);
         assertThat(event, is(expected));
@@ -212,17 +213,27 @@ class LoggingEventTests extends StdIoTests {
 
     static Stream<Arguments> mdcMessageArgs() {
         return Stream.of(
-            arguments((TriFunction<Map<String, String>, String, Object[], LoggingEvent>) LoggingEvent::trace, TRACE),
-            arguments((TriFunction<Map<String, String>, String, Object[], LoggingEvent>) LoggingEvent::debug, DEBUG),
-            arguments((TriFunction<Map<String, String>, String, Object[], LoggingEvent>) LoggingEvent::info,  INFO),
-            arguments((TriFunction<Map<String, String>, String, Object[], LoggingEvent>) LoggingEvent::warn,  WARN),
-            arguments((TriFunction<Map<String, String>, String, Object[], LoggingEvent>) LoggingEvent::error, ERROR)
-        );
+                arguments(
+                        (TriFunction<Map<String, String>, String, Object[], LoggingEvent>) LoggingEvent::trace,
+                        TRACE),
+                arguments(
+                        (TriFunction<Map<String, String>, String, Object[], LoggingEvent>) LoggingEvent::debug,
+                        DEBUG),
+                arguments(
+                        (TriFunction<Map<String, String>, String, Object[], LoggingEvent>) LoggingEvent::info,
+                        INFO),
+                arguments(
+                        (TriFunction<Map<String, String>, String, Object[], LoggingEvent>) LoggingEvent::warn,
+                        WARN),
+                arguments(
+                        (TriFunction<Map<String, String>, String, Object[], LoggingEvent>) LoggingEvent::error,
+                        ERROR));
     }
 
     @ParameterizedTest
     @MethodSource("mdcMessageArgs")
-    void mdcMessageArgs(TriFunction<Map<String, String>, String, Object[], LoggingEvent> producer, Level level) {
+    void mdcMessageArgs(
+            TriFunction<Map<String, String>, String, Object[], LoggingEvent> producer, Level level) {
         LoggingEvent event = producer.apply(mdc, message, new Object[] {arg1, arg2});
         LoggingEvent expected = new LoggingEvent(level, mdc, message, arg1, arg2);
         assertThat(event, is(expected));
@@ -381,12 +392,12 @@ class LoggingEventTests extends StdIoTests {
     @Test
     void mdcNotModifiable() {
         Map<String, String> mdc = Collections.singletonMap("key", "value1");
-        assertThat(new LoggingEvent(level, mdc, message).getMdc(), is(instanceOf(ImmutableMap.class)) );
+        assertThat(new LoggingEvent(level, mdc, message).getMdc(), is(instanceOf(ImmutableMap.class)));
     }
 
     @Test
     void argsIsSnapshotInTime() {
-        Object[] args = new Object[]{arg1, arg2};
+        Object[] args = new Object[] {arg1, arg2};
         Object[] argsAtStart = Arrays.copyOf(args, args.length);
         LoggingEvent event = new LoggingEvent(level, message, args);
         args[0] = "differentArg";
@@ -395,7 +406,8 @@ class LoggingEventTests extends StdIoTests {
 
     @Test
     void argsNotModifiable() {
-        assertThat(new LoggingEvent(level, message, arg1).getArguments(), is(instanceOf(ImmutableList.class)));
+        assertThat(
+                new LoggingEvent(level, message, arg1).getArguments(), is(instanceOf(ImmutableList.class)));
     }
 
     @Test
@@ -427,8 +439,13 @@ class LoggingEventTests extends StdIoTests {
         LoggingEvent event = new LoggingEvent(INFO, "message with {}", "argument");
         event.print();
 
-        assertThat(getStdOut(),
-                is("1970-01-01T00:00:00.000Z ["+Thread.currentThread().getName()+"] INFO - message with argument"+lineSeparator()));
+        assertThat(
+                getStdOut(),
+                is(
+                        "1970-01-01T00:00:00.000Z ["
+                                + Thread.currentThread().getName()
+                                + "] INFO - message with argument"
+                                + lineSeparator()));
     }
 
     @Test
@@ -438,11 +455,16 @@ class LoggingEventTests extends StdIoTests {
         LoggingEvent event = new LoggingEvent(INFO, new Exception(), "message");
         event.print();
 
-        assertThat(getStdOut(),
-                startsWith("1970-01-01T00:00:00.000Z ["+Thread.currentThread().getName()+"] INFO - message"+lineSeparator()
-                        + "java.lang.Exception"+lineSeparator()
-                        + "\tat"
-                ));
+        assertThat(
+                getStdOut(),
+                startsWith(
+                        "1970-01-01T00:00:00.000Z ["
+                                + Thread.currentThread().getName()
+                                + "] INFO - message"
+                                + lineSeparator()
+                                + "java.lang.Exception"
+                                + lineSeparator()
+                                + "\tat"));
     }
 
     @ParameterizedTest

--- a/src/test/java/com/github/valfirst/slf4jtest/OverridablePropertiesTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/OverridablePropertiesTests.java
@@ -1,11 +1,10 @@
 package com.github.valfirst.slf4jtest;
 
-import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.IOException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class OverridablePropertiesTests {
 

--- a/src/test/java/com/github/valfirst/slf4jtest/StdIoTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/StdIoTests.java
@@ -6,7 +6,6 @@ import java.io.PrintStream;
 import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -23,8 +22,7 @@ public class StdIoTests {
     protected String getStdOut() {
         try {
             return out.toString(CHARSET);
-        }
-        catch (UnsupportedEncodingException e) {
+        } catch (UnsupportedEncodingException e) {
             throw new UncheckedIOException(e);
         }
     }
@@ -32,8 +30,7 @@ public class StdIoTests {
     protected String getStdErr() {
         try {
             return err.toString(CHARSET);
-        }
-        catch (UnsupportedEncodingException e) {
+        } catch (UnsupportedEncodingException e) {
             throw new UncheckedIOException(e);
         }
     }
@@ -63,8 +60,7 @@ public class StdIoTests {
     private static PrintStream createPrintStream(ByteArrayOutputStream out) {
         try {
             return new PrintStream(out, true, CHARSET);
-        }
-        catch (UnsupportedEncodingException e) {
+        } catch (UnsupportedEncodingException e) {
             throw new UncheckedIOException(e);
         }
     }

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
@@ -1,5 +1,8 @@
 package com.github.valfirst.slf4jtest;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -9,14 +12,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.org.lidalia.slf4jext.Level;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.when;
-
 @ExtendWith(MockitoExtension.class)
 class TestLoggerAssertionsTest {
 
-    @Mock
-    private TestLogger logger;
+    @Mock private TestLogger logger;
 
     private TestLoggerAssert assertions;
 
@@ -38,41 +37,59 @@ class TestLoggerAssertionsTest {
 
         @Test
         void failsWhenExpectingMoreArgumentsThanExists() {
-            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
+            when(logger.getLoggingEvents())
+                    .thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
 
-            assertThatThrownBy(() -> assertions.hasLogged(Level.WARN, "Something may be wrong", "Extra context"))
+            assertThatThrownBy(
+                            () -> assertions.hasLogged(Level.WARN, "Something may be wrong", "Extra context"))
                     .isInstanceOf(AssertionError.class)
-                    .hasMessage("Failed to find WARN log with message `Something may be wrong` (with arguments)");
+                    .hasMessage(
+                            "Failed to find WARN log with message `Something may be wrong` (with arguments)");
         }
 
         @Test
         void failsWhenActuallyMoreArgumentsThanExpected() {
-            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong", "Extra context", "Another")));
+            when(logger.getLoggingEvents())
+                    .thenReturn(
+                            ImmutableList.of(
+                                    LoggingEvent.warn("Something may be wrong", "Extra context", "Another")));
 
-            assertThatThrownBy(() -> assertions.hasLogged(Level.WARN, "Something may be wrong", "Extra context"))
+            assertThatThrownBy(
+                            () -> assertions.hasLogged(Level.WARN, "Something may be wrong", "Extra context"))
                     .isInstanceOf(AssertionError.class)
-                    .hasMessage("Failed to find WARN log with message `Something may be wrong` (with arguments)");
+                    .hasMessage(
+                            "Failed to find WARN log with message `Something may be wrong` (with arguments)");
         }
 
         @Test
         void failsWhenArgumentsInDifferentOrder() {
-            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong", "Another", "Extra context")));
+            when(logger.getLoggingEvents())
+                    .thenReturn(
+                            ImmutableList.of(
+                                    LoggingEvent.warn("Something may be wrong", "Another", "Extra context")));
 
-            assertThatThrownBy(() -> assertions.hasLogged(Level.WARN, "Something may be wrong", "Extra context", "Another"))
+            assertThatThrownBy(
+                            () ->
+                                    assertions.hasLogged(
+                                            Level.WARN, "Something may be wrong", "Extra context", "Another"))
                     .isInstanceOf(AssertionError.class)
-                    .hasMessage("Failed to find WARN log with message `Something may be wrong` (with arguments)");
+                    .hasMessage(
+                            "Failed to find WARN log with message `Something may be wrong` (with arguments)");
         }
 
         @Test
         void passesWhenLogMessageIsFound() {
-            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
+            when(logger.getLoggingEvents())
+                    .thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
 
-            assertThatCode(() -> assertions.hasLogged(Level.WARN, "Something may be wrong")).doesNotThrowAnyException();
+            assertThatCode(() -> assertions.hasLogged(Level.WARN, "Something may be wrong"))
+                    .doesNotThrowAnyException();
         }
 
         @Test
         void returnsSelfWhenPasses() {
-            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
+            when(logger.getLoggingEvents())
+                    .thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
 
             TestLoggerAssert actual = assertions.hasLogged(Level.WARN, "Something may be wrong");
 
@@ -81,40 +98,49 @@ class TestLoggerAssertionsTest {
 
         @Nested
         class Throwables {
-            @Mock
-            private Throwable throwable;
+            @Mock private Throwable throwable;
 
             @Test
             void canBeUsedToAssertWithThrowablesWhenFound() {
-                when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!")));
+                when(logger.getLoggingEvents())
+                        .thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!")));
 
-                assertThatCode(() -> assertions.hasLogged(throwable, Level.ERROR, "There was a problem!")).doesNotThrowAnyException();
+                assertThatCode(() -> assertions.hasLogged(throwable, Level.ERROR, "There was a problem!"))
+                        .doesNotThrowAnyException();
             }
 
             @Test
             void canBeUsedToAssertWithThrowablesWhenNotFoundWithArguments() {
-                when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.error("There was a problem!", "context")));
+                when(logger.getLoggingEvents())
+                        .thenReturn(ImmutableList.of(LoggingEvent.error("There was a problem!", "context")));
 
-                assertThatThrownBy(() -> assertions.hasLogged(throwable, Level.ERROR, "There was a problem!", "context"))
+                assertThatThrownBy(
+                                () ->
+                                        assertions.hasLogged(throwable, Level.ERROR, "There was a problem!", "context"))
                         .isInstanceOf(AssertionError.class)
-                        .hasMessage("Failed to find ERROR log message with message `There was a problem!` (with throwable and arguments)");
+                        .hasMessage(
+                                "Failed to find ERROR log message with message `There was a problem!` (with throwable and arguments)");
             }
 
             @Test
             void canBeUsedToAssertWithThrowablesWhenNotFound() {
-                when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.error("There was a problem!")));
+                when(logger.getLoggingEvents())
+                        .thenReturn(ImmutableList.of(LoggingEvent.error("There was a problem!")));
 
-                assertThatThrownBy(() -> assertions.hasLogged(throwable, Level.ERROR, "There was a problem!"))
+                assertThatThrownBy(
+                                () -> assertions.hasLogged(throwable, Level.ERROR, "There was a problem!"))
                         .isInstanceOf(AssertionError.class)
-                        .hasMessage("Failed to find ERROR log message with message `There was a problem!` (with throwable)");
+                        .hasMessage(
+                                "Failed to find ERROR log message with message `There was a problem!` (with throwable)");
             }
-
 
             @Test
             void returnsSelfWhenPasses() {
-                when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!")));
+                when(logger.getLoggingEvents())
+                        .thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!")));
 
-                TestLoggerAssert actual = assertions.hasLogged(throwable, Level.ERROR, "There was a problem!");
+                TestLoggerAssert actual =
+                        assertions.hasLogged(throwable, Level.ERROR, "There was a problem!");
 
                 assertThat(actual).isNotNull();
             }
@@ -125,52 +151,74 @@ class TestLoggerAssertionsTest {
     class HasNotLogged {
         @Test
         void failsWhenLogMessageIsFound() {
-            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
+            when(logger.getLoggingEvents())
+                    .thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
 
             assertThatThrownBy(() -> assertions.hasNotLogged(Level.WARN, "Something may be wrong"))
                     .isInstanceOf(AssertionError.class)
-                    .hasMessage("Found WARN log with message `Something may be wrong`, even though we expected not to");
+                    .hasMessage(
+                            "Found WARN log with message `Something may be wrong`, even though we expected not to");
         }
 
         @Test
         void failsWhenExpectingMoreArgumentsThanExists() {
-            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
+            when(logger.getLoggingEvents())
+                    .thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
 
-            assertThatCode(() -> assertions.hasNotLogged(Level.WARN, "Something may be wrong", "Extra context")).doesNotThrowAnyException();
+            assertThatCode(
+                            () -> assertions.hasNotLogged(Level.WARN, "Something may be wrong", "Extra context"))
+                    .doesNotThrowAnyException();
         }
 
         @Test
         void passesWhenActuallyMoreArgumentsThanExpected() {
-            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong", "Extra context", "Another")));
+            when(logger.getLoggingEvents())
+                    .thenReturn(
+                            ImmutableList.of(
+                                    LoggingEvent.warn("Something may be wrong", "Extra context", "Another")));
 
-            assertThatCode(() -> assertions.hasNotLogged(Level.WARN, "Something may be wrong", "Extra context")).doesNotThrowAnyException();
+            assertThatCode(
+                            () -> assertions.hasNotLogged(Level.WARN, "Something may be wrong", "Extra context"))
+                    .doesNotThrowAnyException();
         }
 
         @Test
         void failsWhenArgumentsInDifferentOrder() {
-            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong", "Another", "Extra context")));
+            when(logger.getLoggingEvents())
+                    .thenReturn(
+                            ImmutableList.of(
+                                    LoggingEvent.warn("Something may be wrong", "Another", "Extra context")));
 
-            assertThatCode(() -> assertions.hasNotLogged(Level.WARN, "Something may be wrong", "Extra context", "Another"))
+            assertThatCode(
+                            () ->
+                                    assertions.hasNotLogged(
+                                            Level.WARN, "Something may be wrong", "Extra context", "Another"))
                     .doesNotThrowAnyException();
         }
 
         @Test
         void passesWhenLogMessageIsNotFound() {
-            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.info("Nothing to see here")));
+            when(logger.getLoggingEvents())
+                    .thenReturn(ImmutableList.of(LoggingEvent.info("Nothing to see here")));
 
-            assertThatCode(() -> assertions.hasNotLogged(Level.WARN, "Something may be wrong")).doesNotThrowAnyException();
+            assertThatCode(() -> assertions.hasNotLogged(Level.WARN, "Something may be wrong"))
+                    .doesNotThrowAnyException();
         }
 
         @Test
         void passesWhenLogMessageIsNotFoundWithArguments() {
-            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.info("Nothing to see here", "Context setting")));
+            when(logger.getLoggingEvents())
+                    .thenReturn(
+                            ImmutableList.of(LoggingEvent.info("Nothing to see here", "Context setting")));
 
-            assertThatCode(() -> assertions.hasNotLogged(Level.WARN, "Something may be wrong")).doesNotThrowAnyException();
+            assertThatCode(() -> assertions.hasNotLogged(Level.WARN, "Something may be wrong"))
+                    .doesNotThrowAnyException();
         }
 
         @Test
         void returnsSelfWhenPasses() {
-            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.warn("Something else")));
+            when(logger.getLoggingEvents())
+                    .thenReturn(ImmutableList.of(LoggingEvent.warn("Something else")));
 
             TestLoggerAssert actual = assertions.hasNotLogged(Level.WARN, "Something may be wrong");
 
@@ -179,39 +227,55 @@ class TestLoggerAssertionsTest {
 
         @Nested
         class Throwables {
-            @Mock
-            private Throwable throwable;
+            @Mock private Throwable throwable;
 
             @Test
             void canBeUsedToAssertWithThrowablesWhenNotFound() {
-                when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem, but this isn't what you're looking for!")));
+                when(logger.getLoggingEvents())
+                        .thenReturn(
+                                ImmutableList.of(
+                                        LoggingEvent.error(
+                                                throwable,
+                                                "There was a problem, but this isn't what you're looking for!")));
 
-                assertThatCode(() -> assertions.hasNotLogged(throwable, Level.ERROR, "There was a problem!")).doesNotThrowAnyException();
+                assertThatCode(
+                                () -> assertions.hasNotLogged(throwable, Level.ERROR, "There was a problem!"))
+                        .doesNotThrowAnyException();
             }
 
             @Test
             void canBeUsedToAssertWithThrowablesWhenFoundWithArguments() {
-                when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!", "context")));
+                when(logger.getLoggingEvents())
+                        .thenReturn(
+                                ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!", "context")));
 
-                assertThatThrownBy(() -> assertions.hasNotLogged(throwable, Level.ERROR, "There was a problem!", "context"))
+                assertThatThrownBy(
+                                () ->
+                                        assertions.hasNotLogged(
+                                                throwable, Level.ERROR, "There was a problem!", "context"))
                         .isInstanceOf(AssertionError.class)
-                        .hasMessage("Found ERROR log with message `There was a problem!` (with throwable and arguments), even though we expected not to");
+                        .hasMessage(
+                                "Found ERROR log with message `There was a problem!` (with throwable and arguments), even though we expected not to");
             }
 
             @Test
             void canBeUsedToAssertWithThrowablesWhenFound() {
-                when(logger.getLoggingEvents()).thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!")));
+                when(logger.getLoggingEvents())
+                        .thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!")));
 
-                assertThatThrownBy(() -> assertions.hasNotLogged(throwable, Level.ERROR, "There was a problem!"))
+                assertThatThrownBy(
+                                () -> assertions.hasNotLogged(throwable, Level.ERROR, "There was a problem!"))
                         .isInstanceOf(AssertionError.class)
-                        .hasMessage("Found ERROR log with message `There was a problem!` (with throwable), even though we expected not to");
+                        .hasMessage(
+                                "Found ERROR log with message `There was a problem!` (with throwable), even though we expected not to");
             }
 
             @Test
             void returnsSelfWhenPasses() {
                 when(logger.getLoggingEvents()).thenReturn(ImmutableList.of());
 
-                TestLoggerAssert actual = assertions.hasNotLogged(throwable, Level.ERROR, "There was a problem!");
+                TestLoggerAssert actual =
+                        assertions.hasNotLogged(throwable, Level.ERROR, "There was a problem!");
 
                 assertThat(actual).isNotNull();
             }

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryExtensionTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryExtensionTests.java
@@ -1,15 +1,14 @@
 package com.github.valfirst.slf4jtest;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
-import uk.org.lidalia.slf4jext.LoggerFactory;
-
 import static com.github.valfirst.slf4jtest.LoggingEvent.info;
 import static com.github.valfirst.slf4jtest.TestLoggerFactory.getLoggingEvents;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.lidalia.slf4jext.LoggerFactory;
 
 @ExtendWith(TestLoggerFactoryExtension.class)
 class TestLoggerFactoryExtensionTests {

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryExtensionUnitTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryExtensionUnitTests.java
@@ -1,20 +1,18 @@
 package com.github.valfirst.slf4jtest;
 
-import java.util.Collections;
-import java.util.List;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import uk.org.lidalia.slf4jext.Level;
-
 import static com.github.valfirst.slf4jtest.LoggingEvent.info;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static uk.org.lidalia.slf4jext.Level.DEBUG;
 import static uk.org.lidalia.slf4jext.Level.INFO;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.org.lidalia.slf4jext.Level;
 
 class TestLoggerFactoryExtensionUnitTests {
 

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryResetRuleTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryResetRuleTests.java
@@ -1,16 +1,15 @@
 package com.github.valfirst.slf4jtest;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-
-import uk.org.lidalia.slf4jext.LoggerFactory;
-
 import static com.github.valfirst.slf4jtest.LoggingEvent.info;
 import static com.github.valfirst.slf4jtest.TestLoggerFactory.getLoggingEvents;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import uk.org.lidalia.slf4jext.LoggerFactory;
 
 public class TestLoggerFactoryResetRuleTests {
 

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryResetRuleUnitTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryResetRuleUnitTests.java
@@ -1,16 +1,5 @@
 package com.github.valfirst.slf4jtest;
 
-import java.util.Collections;
-import java.util.List;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
-
-import uk.org.lidalia.slf4jext.Level;
-
 import static com.github.valfirst.slf4jtest.LoggingEvent.info;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -18,6 +7,15 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.org.lidalia.slf4jext.Level.DEBUG;
 import static uk.org.lidalia.slf4jext.Level.INFO;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import uk.org.lidalia.slf4jext.Level;
 
 class TestLoggerFactoryResetRuleUnitTests {
 
@@ -30,16 +28,22 @@ class TestLoggerFactoryResetRuleUnitTests {
         logger.setEnabledLevels(INFO, DEBUG);
         logger.info("a message");
 
-        resetRule.apply(new Statement() {
-            @Override
-            public void evaluate() {
-                assertThat(TestLoggerFactory.getLoggingEvents(), is(Collections.<LoggingEvent>emptyList()));
-                assertThat(logger.getLoggingEvents(), is(Collections.<LoggingEvent>emptyList()));
-                assertThat(logger.getEnabledLevels(), is(Level.enablableValueSet()));
-            }
-        }, Description.EMPTY).evaluate();
+        resetRule
+                .apply(
+                        new Statement() {
+                            @Override
+                            public void evaluate() {
+                                assertThat(
+                                        TestLoggerFactory.getLoggingEvents(),
+                                        is(Collections.<LoggingEvent>emptyList()));
+                                assertThat(logger.getLoggingEvents(), is(Collections.<LoggingEvent>emptyList()));
+                                assertThat(logger.getEnabledLevels(), is(Level.enablableValueSet()));
+                            }
+                        },
+                        Description.EMPTY)
+                .evaluate();
     }
-    
+
     @Test
     void resetsThreadLocalDataAfterTest() throws Throwable {
 
@@ -47,12 +51,14 @@ class TestLoggerFactoryResetRuleUnitTests {
         logger.setEnabledLevels(INFO, DEBUG);
         logger.info("a message");
 
-        resetRule.apply(new Statement() {
-            @Override
-            public void evaluate() {
-            }
-        }, Description.EMPTY).evaluate();
-
+        resetRule
+                .apply(
+                        new Statement() {
+                            @Override
+                            public void evaluate() {}
+                        },
+                        Description.EMPTY)
+                .evaluate();
 
         assertThat(TestLoggerFactory.getLoggingEvents(), is(Collections.<LoggingEvent>emptyList()));
         assertThat(logger.getLoggingEvents(), is(Collections.<LoggingEvent>emptyList()));
@@ -67,12 +73,20 @@ class TestLoggerFactoryResetRuleUnitTests {
         logger.info("a message");
 
         final RuntimeException toThrow = new RuntimeException();
-        Exception thrown = assertThrows(Exception.class, () -> resetRule.apply(new Statement() {
-            @Override
-            public void evaluate() {
-                throw toThrow;
-            }
-        }, Description.EMPTY).evaluate());
+        Exception thrown =
+                assertThrows(
+                        Exception.class,
+                        () ->
+                                resetRule
+                                        .apply(
+                                                new Statement() {
+                                                    @Override
+                                                    public void evaluate() {
+                                                        throw toThrow;
+                                                    }
+                                                },
+                                                Description.EMPTY)
+                                        .evaluate());
 
         assertThat(thrown, is(toThrow));
         assertThat(TestLoggerFactory.getLoggingEvents(), is(Collections.<LoggingEvent>emptyList()));
@@ -86,11 +100,14 @@ class TestLoggerFactoryResetRuleUnitTests {
         final TestLogger logger = TestLoggerFactory.getTestLogger("logger_name");
         logger.info("a message");
 
-        resetRule.apply(new Statement() {
-            @Override
-            public void evaluate() {
-            }
-        }, Description.EMPTY).evaluate();
+        resetRule
+                .apply(
+                        new Statement() {
+                            @Override
+                            public void evaluate() {}
+                        },
+                        Description.EMPTY)
+                .evaluate();
 
         final List<LoggingEvent> loggedEvents = singletonList(info("a message"));
 

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryTests.java
@@ -1,20 +1,5 @@
 package com.github.valfirst.slf4jtest;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-
-import uk.org.lidalia.slf4jext.Level;
-
 import static com.github.valfirst.slf4jtest.LoggingEvent.debug;
 import static com.github.valfirst.slf4jtest.LoggingEvent.info;
 import static com.github.valfirst.slf4jtest.LoggingEvent.trace;
@@ -32,6 +17,19 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 import static uk.org.lidalia.slf4jext.Level.WARN;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import uk.org.lidalia.slf4jext.Level;
 
 @RunWith(PowerMockRunner.class)
 public class TestLoggerFactoryTests {
@@ -93,12 +91,9 @@ public class TestLoggerFactoryTests {
         logger1.trace("here");
         logger2.trace("I am");
 
-        assertThat(TestLoggerFactory.getLoggingEvents(),
-                is(asList(
-                        trace("hello"),
-                        trace("world"),
-                        trace("here"),
-                        trace("I am"))));
+        assertThat(
+                TestLoggerFactory.getLoggingEvents(),
+                is(asList(trace("hello"), trace("world"), trace("here"), trace("I am"))));
     }
 
     @Test
@@ -108,12 +103,8 @@ public class TestLoggerFactoryTests {
         logger1.trace("hello");
         logger2.trace("world");
 
-        assertThat(logger1.getLoggingEvents(),
-                is(singletonList(trace("hello"))
-                ));
-        assertThat(logger2.getLoggingEvents(),
-                is(singletonList(trace("world"))
-                ));
+        assertThat(logger1.getLoggingEvents(), is(singletonList(trace("hello"))));
+        assertThat(logger2.getLoggingEvents(), is(singletonList(trace("world"))));
     }
 
     @Test
@@ -140,7 +131,8 @@ public class TestLoggerFactoryTests {
         TestLogger logger1 = getInstance().getLogger("name1");
         TestLoggerFactory.clear();
 
-        assertThat(TestLoggerFactory.getAllTestLoggers(), is(Collections.singletonMap("name1", logger1)));
+        assertThat(
+                TestLoggerFactory.getAllTestLoggers(), is(Collections.singletonMap("name1", logger1)));
     }
 
     @Test
@@ -190,7 +182,8 @@ public class TestLoggerFactoryTests {
     public void getAllLoggersReturnsUnmodifiableList() {
         Map<String, TestLogger> allTestLoggers = TestLoggerFactory.getAllTestLoggers();
         TestLogger newLogger = new TestLogger("newlogger", getInstance());
-        assertThrows(UnsupportedOperationException.class, () -> allTestLoggers.put("newlogger", newLogger));
+        assertThrows(
+                UnsupportedOperationException.class, () -> allTestLoggers.put("newlogger", newLogger));
     }
 
     @Test
@@ -207,7 +200,8 @@ public class TestLoggerFactoryTests {
         t.start();
         t.join();
         TestLoggerFactory.getTestLogger("name1").info("message2");
-        assertThat(TestLoggerFactory.getAllLoggingEvents(), is(asList(info("message1"), info("message2"))));
+        assertThat(
+                TestLoggerFactory.getAllLoggingEvents(), is(asList(info("message1"), info("message2"))));
     }
 
     @Test
@@ -226,11 +220,13 @@ public class TestLoggerFactoryTests {
         final TestLogger logger2 = TestLoggerFactory.getTestLogger("name2");
         logger1.info("hello11");
         logger2.info("hello21");
-        Thread t = new Thread(() -> {
-            logger1.info("hello12");
-            logger2.info("hello22");
-            TestLoggerFactory.clearAll();
-        });
+        Thread t =
+                new Thread(
+                        () -> {
+                            logger1.info("hello12");
+                            logger2.info("hello22");
+                            TestLoggerFactory.clearAll();
+                        });
         t.start();
         t.join();
         assertThat(TestLoggerFactory.getLoggingEvents(), is(empty()));
@@ -264,15 +260,17 @@ public class TestLoggerFactoryTests {
         final String invalidLevelName = "nonsense";
         when(properties.getProperty("print.level", "OFF")).thenReturn(invalidLevelName);
 
-        final IllegalStateException illegalStateException = assertThrows(IllegalStateException.class,
-                TestLoggerFactory::getInstance);
-        assertThat(illegalStateException.getMessage(),
-                is("Invalid level name in property print.level of file slf4jtest.properties " +
-                        "or System property slf4jtest.print.level"));
+        final IllegalStateException illegalStateException =
+                assertThrows(IllegalStateException.class, TestLoggerFactory::getInstance);
+        assertThat(
+                illegalStateException.getMessage(),
+                is(
+                        "Invalid level name in property print.level of file slf4jtest.properties "
+                                + "or System property slf4jtest.print.level"));
         assertThat(illegalStateException.getCause(), instanceOf(IllegalArgumentException.class));
-        assertThat(illegalStateException.getCause().getMessage(),
-                is("No enum constant "+Level.class.getName()+"."+invalidLevelName));
-
+        assertThat(
+                illegalStateException.getCause().getMessage(),
+                is("No enum constant " + Level.class.getName() + "." + invalidLevelName));
     }
 
     @Test
@@ -281,14 +279,14 @@ public class TestLoggerFactoryTests {
         IOException ioException = new IOException();
         whenNew(OverridableProperties.class).withArguments("slf4jtest").thenThrow(ioException);
 
-        final UncheckedIOException uncheckedIOException = assertThrows(UncheckedIOException.class,
-                TestLoggerFactory::getInstance);
+        final UncheckedIOException uncheckedIOException =
+                assertThrows(UncheckedIOException.class, TestLoggerFactory::getInstance);
         assertThat(uncheckedIOException.getCause(), is(ioException));
     }
 
     @Test
     public void setLevel() {
-        for (Level printLevel: Level.values()) {
+        for (Level printLevel : Level.values()) {
             getInstance().setPrintLevel(printLevel);
             assertThat(getInstance().getPrintLevel(), is(printLevel));
         }

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerTests.java
@@ -1,26 +1,5 @@
 package com.github.valfirst.slf4jtest;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.slf4j.MDC;
-import org.slf4j.Marker;
-
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-
-import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jext.Logger;
-
 import static com.github.valfirst.slf4jtest.LoggingEvent.debug;
 import static com.github.valfirst.slf4jtest.LoggingEvent.error;
 import static com.github.valfirst.slf4jtest.LoggingEvent.info;
@@ -47,17 +26,36 @@ import static uk.org.lidalia.slf4jext.Level.TRACE;
 import static uk.org.lidalia.slf4jext.Level.WARN;
 import static uk.org.lidalia.slf4jext.Level.enablableValueSet;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.slf4j.Marker;
+import uk.org.lidalia.slf4jext.Level;
+import uk.org.lidalia.slf4jext.Logger;
+
 class TestLoggerTests extends StdIoTests {
 
     private static final String LOGGER_NAME = "uk.org";
-    private final TestLogger testLogger = new TestLogger(LOGGER_NAME, TestLoggerFactory.getInstance());
+    private final TestLogger testLogger =
+            new TestLogger(LOGGER_NAME, TestLoggerFactory.getInstance());
     private final Marker marker = mock(Marker.class);
     private final String message = "message {} {} {}";
     private final Object arg1 = "arg1";
     private final Object arg2 = "arg2";
-    private final Object[] args = new Object[]{arg1, arg2, "arg3"};
+    private final Object[] args = new Object[] {arg1, arg2, "arg3"};
     private final Throwable throwable = new Throwable();
-    private final Object[] argsWithThrowable = new Object[]{arg1, arg2, "arg3", throwable};
+    private final Object[] argsWithThrowable = new Object[] {arg1, arg2, "arg3", throwable};
 
     private final Map<String, String> mdcValues = new HashMap<>();
 
@@ -86,7 +84,9 @@ class TestLoggerTests extends StdIoTests {
     void clearRemovesEvents() {
         testLogger.debug("message1");
         testLogger.debug("message2");
-        assertEquals(asList(debug(mdcValues, "message1"), debug(mdcValues, "message2")), testLogger.getLoggingEvents());
+        assertEquals(
+                asList(debug(mdcValues, "message1"), debug(mdcValues, "message2")),
+                testLogger.getLoggingEvents());
         testLogger.clear();
         assertEquals(emptyList(), testLogger.getLoggingEvents());
     }
@@ -121,7 +121,8 @@ class TestLoggerTests extends StdIoTests {
     void traceMessageTwoArgs() {
         testLogger.trace(message, arg1, arg2);
 
-        assertEquals(singletonList(trace(mdcValues, message, arg1, arg2)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(trace(mdcValues, message, arg1, arg2)), testLogger.getLoggingEvents());
     }
 
     @Test
@@ -135,14 +136,16 @@ class TestLoggerTests extends StdIoTests {
     void traceMessageManyArgsWithThrowable() {
         testLogger.trace(message, argsWithThrowable);
 
-        assertEquals(singletonList(trace(mdcValues, throwable, message, args)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(trace(mdcValues, throwable, message, args)), testLogger.getLoggingEvents());
     }
 
     @Test
     void traceMessageThrowable() {
         testLogger.trace(message, throwable);
 
-        assertEquals(singletonList(trace(mdcValues, throwable, message)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(trace(mdcValues, throwable, message)), testLogger.getLoggingEvents());
     }
 
     @Test
@@ -161,35 +164,42 @@ class TestLoggerTests extends StdIoTests {
     void traceMarkerMessageOneArg() {
         testLogger.trace(marker, message, arg1);
 
-        assertEquals(singletonList(trace(mdcValues, marker, message, arg1)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(trace(mdcValues, marker, message, arg1)), testLogger.getLoggingEvents());
     }
 
     @Test
     void traceMarkerMessageTwoArgs() {
         testLogger.trace(marker, message, arg1, arg2);
 
-        assertEquals(singletonList(trace(mdcValues, marker, message, arg1, arg2)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(trace(mdcValues, marker, message, arg1, arg2)),
+                testLogger.getLoggingEvents());
     }
 
     @Test
     void traceMarkerMessageManyArgs() {
         testLogger.trace(marker, message, args);
 
-        assertEquals(singletonList(trace(mdcValues, marker, message, args)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(trace(mdcValues, marker, message, args)), testLogger.getLoggingEvents());
     }
 
     @Test
     void traceMarkerMessageManyArgsWithThrowable() {
         testLogger.trace(marker, message, argsWithThrowable);
 
-        assertEquals(singletonList(trace(mdcValues, marker, throwable, message, args)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(trace(mdcValues, marker, throwable, message, args)),
+                testLogger.getLoggingEvents());
     }
 
     @Test
     void traceMarkerMessageThrowable() {
         testLogger.trace(marker, message, throwable);
 
-        assertEquals(singletonList(trace(mdcValues, marker, throwable, message)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(trace(mdcValues, marker, throwable, message)), testLogger.getLoggingEvents());
     }
 
     @Test
@@ -215,7 +225,8 @@ class TestLoggerTests extends StdIoTests {
     void debugMessageTwoArgs() {
         testLogger.debug(message, arg1, arg2);
 
-        assertEquals(singletonList(debug(mdcValues, message, arg1, arg2)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(debug(mdcValues, message, arg1, arg2)), testLogger.getLoggingEvents());
     }
 
     @Test
@@ -229,14 +240,16 @@ class TestLoggerTests extends StdIoTests {
     void debugMessageManyArgsWithThrowable() {
         testLogger.debug(message, argsWithThrowable);
 
-        assertEquals(singletonList(debug(mdcValues, throwable, message, args)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(debug(mdcValues, throwable, message, args)), testLogger.getLoggingEvents());
     }
 
     @Test
     void debugMessageThrowable() {
         testLogger.debug(message, throwable);
 
-        assertEquals(singletonList(debug(mdcValues, throwable, message)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(debug(mdcValues, throwable, message)), testLogger.getLoggingEvents());
     }
 
     @Test
@@ -255,35 +268,42 @@ class TestLoggerTests extends StdIoTests {
     void debugMarkerMessageOneArg() {
         testLogger.debug(marker, message, arg1);
 
-        assertEquals(singletonList(debug(mdcValues, marker, message, arg1)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(debug(mdcValues, marker, message, arg1)), testLogger.getLoggingEvents());
     }
 
     @Test
     void debugMarkerMessageTwoArgs() {
         testLogger.debug(marker, message, arg1, arg2);
 
-        assertEquals(singletonList(debug(mdcValues, marker, message, arg1, arg2)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(debug(mdcValues, marker, message, arg1, arg2)),
+                testLogger.getLoggingEvents());
     }
 
     @Test
     void debugMarkerMessageManyArgs() {
         testLogger.debug(marker, message, args);
 
-        assertEquals(singletonList(debug(mdcValues, marker, message, args)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(debug(mdcValues, marker, message, args)), testLogger.getLoggingEvents());
     }
 
     @Test
     void debugMarkerMessageManyArgsWithThrowable() {
         testLogger.debug(marker, message, argsWithThrowable);
 
-        assertEquals(singletonList(debug(mdcValues, marker, throwable, message, args)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(debug(mdcValues, marker, throwable, message, args)),
+                testLogger.getLoggingEvents());
     }
 
     @Test
     void debugMarkerMessageThrowable() {
         testLogger.debug(marker, message, throwable);
 
-        assertEquals(singletonList(debug(mdcValues, marker, throwable, message)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(debug(mdcValues, marker, throwable, message)), testLogger.getLoggingEvents());
     }
 
     @Test
@@ -309,7 +329,8 @@ class TestLoggerTests extends StdIoTests {
     void infoMessageTwoArgs() {
         testLogger.info(message, arg1, arg2);
 
-        assertEquals(singletonList(info(mdcValues, message, arg1, arg2)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(info(mdcValues, message, arg1, arg2)), testLogger.getLoggingEvents());
     }
 
     @Test
@@ -323,7 +344,8 @@ class TestLoggerTests extends StdIoTests {
     void infoMessageManyArgsWithThrowable() {
         testLogger.info(message, argsWithThrowable);
 
-        assertEquals(singletonList(info(mdcValues, throwable, message, args)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(info(mdcValues, throwable, message, args)), testLogger.getLoggingEvents());
     }
 
     @Test
@@ -349,35 +371,41 @@ class TestLoggerTests extends StdIoTests {
     void infoMarkerMessageOneArg() {
         testLogger.info(marker, message, arg1);
 
-        assertEquals(singletonList(info(mdcValues, marker, message, arg1)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(info(mdcValues, marker, message, arg1)), testLogger.getLoggingEvents());
     }
 
     @Test
     void infoMarkerMessageTwoArgs() {
         testLogger.info(marker, message, arg1, arg2);
 
-        assertEquals(singletonList(info(mdcValues, marker, message, arg1, arg2)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(info(mdcValues, marker, message, arg1, arg2)), testLogger.getLoggingEvents());
     }
 
     @Test
     void infoMarkerMessageManyArgs() {
         testLogger.info(marker, message, args);
 
-        assertEquals(singletonList(info(mdcValues, marker, message, args)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(info(mdcValues, marker, message, args)), testLogger.getLoggingEvents());
     }
 
     @Test
     void infoMarkerMessageManyArgsWithThrowable() {
         testLogger.info(marker, message, argsWithThrowable);
 
-        assertEquals(singletonList(info(mdcValues, marker, throwable, message, args)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(info(mdcValues, marker, throwable, message, args)),
+                testLogger.getLoggingEvents());
     }
 
     @Test
     void infoMarkerMessageThrowable() {
         testLogger.info(marker, message, throwable);
 
-        assertEquals(singletonList(info(mdcValues, marker, throwable, message)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(info(mdcValues, marker, throwable, message)), testLogger.getLoggingEvents());
     }
 
     @Test
@@ -403,7 +431,8 @@ class TestLoggerTests extends StdIoTests {
     void warnMessageTwoArgs() {
         testLogger.warn(message, arg1, arg2);
 
-        assertEquals(singletonList(warn(mdcValues, message, arg1, arg2)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(warn(mdcValues, message, arg1, arg2)), testLogger.getLoggingEvents());
     }
 
     @Test
@@ -417,7 +446,8 @@ class TestLoggerTests extends StdIoTests {
     void warnMessageManyArgsWithThrowable() {
         testLogger.warn(message, argsWithThrowable);
 
-        assertEquals(singletonList(warn(mdcValues, throwable, message, args)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(warn(mdcValues, throwable, message, args)), testLogger.getLoggingEvents());
     }
 
     @Test
@@ -443,35 +473,41 @@ class TestLoggerTests extends StdIoTests {
     void warnMarkerMessageOneArg() {
         testLogger.warn(marker, message, arg1);
 
-        assertEquals(singletonList(warn(mdcValues, marker, message, arg1)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(warn(mdcValues, marker, message, arg1)), testLogger.getLoggingEvents());
     }
 
     @Test
     void warnMarkerMessageTwoArgs() {
         testLogger.warn(marker, message, arg1, arg2);
 
-        assertEquals(singletonList(warn(mdcValues, marker, message, arg1, arg2)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(warn(mdcValues, marker, message, arg1, arg2)), testLogger.getLoggingEvents());
     }
 
     @Test
     void warnMarkerMessageManyArgs() {
         testLogger.warn(marker, message, args);
 
-        assertEquals(singletonList(warn(mdcValues, marker, message, args)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(warn(mdcValues, marker, message, args)), testLogger.getLoggingEvents());
     }
 
     @Test
     void warnMarkerMessageManyArgsWithThrowable() {
         testLogger.warn(marker, message, argsWithThrowable);
 
-        assertEquals(singletonList(warn(mdcValues, marker, throwable, message, args)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(warn(mdcValues, marker, throwable, message, args)),
+                testLogger.getLoggingEvents());
     }
 
     @Test
     void warnMarkerMessageThrowable() {
         testLogger.warn(marker, message, throwable);
 
-        assertEquals(singletonList(warn(mdcValues, marker, throwable, message)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(warn(mdcValues, marker, throwable, message)), testLogger.getLoggingEvents());
     }
 
     @Test
@@ -497,7 +533,8 @@ class TestLoggerTests extends StdIoTests {
     void errorMessageTwoArgs() {
         testLogger.error(message, arg1, arg2);
 
-        assertEquals(singletonList(error(mdcValues, message, arg1, arg2)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(error(mdcValues, message, arg1, arg2)), testLogger.getLoggingEvents());
     }
 
     @Test
@@ -511,14 +548,16 @@ class TestLoggerTests extends StdIoTests {
     void errorMessageManyArgsWithThrowable() {
         testLogger.error(message, argsWithThrowable);
 
-        assertEquals(singletonList(error(mdcValues, throwable, message, args)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(error(mdcValues, throwable, message, args)), testLogger.getLoggingEvents());
     }
 
     @Test
     void errorMessageThrowable() {
         testLogger.error(message, throwable);
 
-        assertEquals(singletonList(error(mdcValues, throwable, message)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(error(mdcValues, throwable, message)), testLogger.getLoggingEvents());
     }
 
     @Test
@@ -537,35 +576,42 @@ class TestLoggerTests extends StdIoTests {
     void errorMarkerMessageOneArg() {
         testLogger.error(marker, message, arg1);
 
-        assertEquals(singletonList(error(mdcValues, marker, message, arg1)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(error(mdcValues, marker, message, arg1)), testLogger.getLoggingEvents());
     }
 
     @Test
     void errorMarkerMessageTwoArgs() {
         testLogger.error(marker, message, arg1, arg2);
 
-        assertEquals(singletonList(error(mdcValues, marker, message, arg1, arg2)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(error(mdcValues, marker, message, arg1, arg2)),
+                testLogger.getLoggingEvents());
     }
 
     @Test
     void errorMarkerMessageManyArgs() {
         testLogger.error(marker, message, args);
 
-        assertEquals(singletonList(error(mdcValues, marker, message, args)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(error(mdcValues, marker, message, args)), testLogger.getLoggingEvents());
     }
 
     @Test
     void errorMarkerMessageManyArgsWithThrowable() {
         testLogger.error(marker, message, argsWithThrowable);
 
-        assertEquals(singletonList(error(mdcValues, marker, throwable, message, args)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(error(mdcValues, marker, throwable, message, args)),
+                testLogger.getLoggingEvents());
     }
 
     @Test
     void errorMarkerMessageThrowable() {
         testLogger.error(marker, message, throwable);
 
-        assertEquals(singletonList(error(mdcValues, marker, throwable, message)), testLogger.getLoggingEvents());
+        assertEquals(
+                singletonList(error(mdcValues, marker, throwable, message)), testLogger.getLoggingEvents());
     }
 
     @Test
@@ -606,8 +652,10 @@ class TestLoggerTests extends StdIoTests {
         testLogger.debug(message);
         testLogger.trace(message);
 
-        List<LoggingEvent> expectedEvents = Arrays.stream(shouldLog).map(
-                level -> new LoggingEvent(level, mdcValues, message)).collect(Collectors.toList());
+        List<LoggingEvent> expectedEvents =
+                Arrays.stream(shouldLog)
+                        .map(level -> new LoggingEvent(level, mdcValues, message))
+                        .collect(Collectors.toList());
 
         assertEquals(expectedEvents, testLogger.getLoggingEvents());
         testLogger.clear();
@@ -658,10 +706,12 @@ class TestLoggerTests extends StdIoTests {
     @Test
     void clearAllClearsEventsLoggedInAllThreads() throws InterruptedException {
         testLogger.info(message);
-        Thread t = new Thread(() -> {
-            testLogger.info(message);
-            testLogger.clearAll();
-        });
+        Thread t =
+                new Thread(
+                        () -> {
+                            testLogger.info(message);
+                            testLogger.clearAll();
+                        });
         t.start();
         t.join();
         assertEquals(emptyList(), testLogger.getAllLoggingEvents());
@@ -671,10 +721,12 @@ class TestLoggerTests extends StdIoTests {
     @Test
     void setEnabledLevelOnlyChangesLevelForCurrentThread() throws Exception {
         final AtomicReference<ImmutableSet<Level>> inThreadEnabledLevels = new AtomicReference<>();
-        Thread t = new Thread(() -> {
-            testLogger.setEnabledLevels(WARN, ERROR);
-            inThreadEnabledLevels.set(testLogger.getEnabledLevels());
-        });
+        Thread t =
+                new Thread(
+                        () -> {
+                            testLogger.setEnabledLevels(WARN, ERROR);
+                            inThreadEnabledLevels.set(testLogger.getEnabledLevels());
+                        });
         t.start();
         t.join();
         assertEquals(ImmutableSet.of(WARN, ERROR), inThreadEnabledLevels.get());
@@ -693,10 +745,12 @@ class TestLoggerTests extends StdIoTests {
     @Test
     void setEnabledLevelsForAllThreads() throws Exception {
         final AtomicReference<ImmutableSet<Level>> inThreadEnabledLevels = new AtomicReference<>();
-        Thread t = new Thread(() -> {
-            testLogger.setEnabledLevelsForAllThreads(WARN, ERROR);
-            inThreadEnabledLevels.set(testLogger.getEnabledLevels());
-        });
+        Thread t =
+                new Thread(
+                        () -> {
+                            testLogger.setEnabledLevelsForAllThreads(WARN, ERROR);
+                            inThreadEnabledLevels.set(testLogger.getEnabledLevels());
+                        });
         t.start();
         t.join();
         assertEquals(ImmutableSet.of(WARN, ERROR), inThreadEnabledLevels.get());
@@ -746,30 +800,35 @@ class TestLoggerTests extends StdIoTests {
 
         testLogger.info(message);
 
-        assertThat(testLogger.getLoggingEvents(), is(
-                singletonList(info(ImmutableMap.of("key", "null"), message))));
+        assertThat(
+                testLogger.getLoggingEvents(),
+                is(singletonList(info(ImmutableMap.of("key", "null"), message))));
     }
 
     private void assertEnabledReturnsCorrectly(Level levelToTest) {
         testLogger.setEnabledLevels(levelToTest);
-        assertTrue(new Logger(testLogger).isEnabled(levelToTest),
+        assertTrue(
+                new Logger(testLogger).isEnabled(levelToTest),
                 "Logger level set to " + levelToTest + " means " + levelToTest + " should be enabled");
 
         Set<Level> disabledLevels = difference(enablableValueSet(), newHashSet(levelToTest));
-        for (Level disabledLevel: disabledLevels) {
-            assertFalse(new Logger(testLogger).isEnabled(disabledLevel),
+        for (Level disabledLevel : disabledLevels) {
+            assertFalse(
+                    new Logger(testLogger).isEnabled(disabledLevel),
                     "Logger level set to " + levelToTest + " means " + levelToTest + " should be disabled");
         }
     }
 
     private void assertEnabledReturnsCorrectly(Level levelToTest, Marker marker) {
         testLogger.setEnabledLevels(levelToTest);
-        assertTrue(new Logger(testLogger).isEnabled(levelToTest, marker),
+        assertTrue(
+                new Logger(testLogger).isEnabled(levelToTest, marker),
                 "Logger level set to " + levelToTest + " means " + levelToTest + " should be enabled");
 
         Set<Level> disabledLevels = difference(enablableValueSet(), newHashSet(levelToTest));
-        for (Level disabledLevel: disabledLevels) {
-            assertFalse(new Logger(testLogger).isEnabled(disabledLevel, marker),
+        for (Level disabledLevel : disabledLevels) {
+            assertFalse(
+                    new Logger(testLogger).isEnabled(disabledLevel, marker),
                     "Logger level set to " + levelToTest + " means " + levelToTest + " should be disabled");
         }
     }

--- a/src/test/java/com/github/valfirst/slf4jtest/TestMDCAdapterTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestMDCAdapterTests.java
@@ -1,14 +1,13 @@
 package com.github.valfirst.slf4jtest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 class TestMDCAdapterTests {
 
@@ -60,26 +59,30 @@ class TestMDCAdapterTests {
     void testMdcAdapterIsThreadLocal() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(2);
         final Map<String, String> results = new HashMap<>();
-        Thread thread1 = new Thread(() -> {
-            testMDCAdapter.put(key, "value1");
-            latch.countDown();
-            try {
-                latch.await();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-            results.put("thread1", testMDCAdapter.get(key));
-        });
-        Thread thread2 = new Thread(() -> {
-            testMDCAdapter.put(key, "value2");
-            latch.countDown();
-            try {
-                latch.await();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-            results.put("thread2", testMDCAdapter.get(key));
-        });
+        Thread thread1 =
+                new Thread(
+                        () -> {
+                            testMDCAdapter.put(key, "value1");
+                            latch.countDown();
+                            try {
+                                latch.await();
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                            results.put("thread1", testMDCAdapter.get(key));
+                        });
+        Thread thread2 =
+                new Thread(
+                        () -> {
+                            testMDCAdapter.put(key, "value2");
+                            latch.countDown();
+                            try {
+                                latch.await();
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                            results.put("thread2", testMDCAdapter.get(key));
+                        });
         thread1.start();
         thread2.start();
         thread1.join();

--- a/src/test/java/com/github/valfirst/slf4jtest/TestSLF4JServiceProviderTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestSLF4JServiceProviderTests.java
@@ -1,7 +1,12 @@
 package com.github.valfirst.slf4jtest;
 
-import java.util.ServiceLoader;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
+import java.util.ServiceLoader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
@@ -10,18 +15,10 @@ import org.slf4j.MarkerFactory;
 import org.slf4j.helpers.BasicMarkerFactory;
 import org.slf4j.spi.SLF4JServiceProvider;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-
-/**
- * @author Valery Yatsynovich
- */
+/** @author Valery Yatsynovich */
 class TestSLF4JServiceProviderTests {
-    private SLF4JServiceProvider slf4JServiceProvider = ServiceLoader.load(SLF4JServiceProvider.class).iterator()
-            .next();
+    private SLF4JServiceProvider slf4JServiceProvider =
+            ServiceLoader.load(SLF4JServiceProvider.class).iterator().next();
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/org/slf4j/impl/StaticLoggerBinderTests.java
+++ b/src/test/java/org/slf4j/impl/StaticLoggerBinderTests.java
@@ -1,26 +1,28 @@
 package org.slf4j.impl;
 
-import org.junit.jupiter.api.Test;
-import org.slf4j.ILoggerFactory;
-import org.slf4j.LoggerFactory;
-
-import com.github.valfirst.slf4jtest.TestLoggerFactory;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
+import org.junit.jupiter.api.Test;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
+
 class StaticLoggerBinderTests {
 
     @Test
     void getLoggerFactory() {
-        assertSame(TestLoggerFactory.getInstance(), StaticLoggerBinder.getSingleton().getLoggerFactory());
+        assertSame(
+                TestLoggerFactory.getInstance(), StaticLoggerBinder.getSingleton().getLoggerFactory());
     }
 
     @Test
     void getLoggerFactoryClassStr() {
-        assertEquals("com.github.valfirst.slf4jtest.TestLoggerFactory", StaticLoggerBinder.getSingleton().getLoggerFactoryClassStr());
+        assertEquals(
+                "com.github.valfirst.slf4jtest.TestLoggerFactory",
+                StaticLoggerBinder.getSingleton().getLoggerFactoryClassStr());
     }
 
     @Test

--- a/src/test/java/org/slf4j/impl/StaticMDCBinderTests.java
+++ b/src/test/java/org/slf4j/impl/StaticMDCBinderTests.java
@@ -1,14 +1,13 @@
 package org.slf4j.impl;
 
-import org.junit.jupiter.api.Test;
-import org.slf4j.MDC;
-
-import com.github.valfirst.slf4jtest.TestMDCAdapter;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.github.valfirst.slf4jtest.TestMDCAdapter;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
 
 class StaticMDCBinderTests {
 
@@ -20,7 +19,9 @@ class StaticMDCBinderTests {
 
     @Test
     void getMDCAdapterClassStr() {
-        assertEquals("com.github.valfirst.slf4jtest.TestMDCAdapter", StaticMDCBinder.SINGLETON.getMDCAdapterClassStr());
+        assertEquals(
+                "com.github.valfirst.slf4jtest.TestMDCAdapter",
+                StaticMDCBinder.SINGLETON.getMDCAdapterClassStr());
     }
 
     @Test

--- a/src/test/java/org/slf4j/impl/StaticMarkerBinderTests.java
+++ b/src/test/java/org/slf4j/impl/StaticMarkerBinderTests.java
@@ -1,25 +1,30 @@
 package org.slf4j.impl;
 
-import org.junit.jupiter.api.Test;
-import org.slf4j.MarkerFactory;
-import org.slf4j.helpers.BasicMarkerFactory;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import org.junit.jupiter.api.Test;
+import org.slf4j.MarkerFactory;
+import org.slf4j.helpers.BasicMarkerFactory;
+
 class StaticMarkerBinderTests {
 
     @Test
     void getMarkerFactory() {
-        assertSame(BasicMarkerFactory.class, StaticMarkerBinder.SINGLETON.getMarkerFactory().getClass());
-        assertSame(StaticMarkerBinder.SINGLETON.getMarkerFactory(), StaticMarkerBinder.SINGLETON.getMarkerFactory());
+        assertSame(
+                BasicMarkerFactory.class, StaticMarkerBinder.SINGLETON.getMarkerFactory().getClass());
+        assertSame(
+                StaticMarkerBinder.SINGLETON.getMarkerFactory(),
+                StaticMarkerBinder.SINGLETON.getMarkerFactory());
     }
 
     @Test
     void getMarkerFactoryClassStr() {
-        assertEquals("org.slf4j.helpers.BasicMarkerFactory", StaticMarkerBinder.SINGLETON.getMarkerFactoryClassStr());
+        assertEquals(
+                "org.slf4j.helpers.BasicMarkerFactory",
+                StaticMarkerBinder.SINGLETON.getMarkerFactoryClassStr());
     }
 
     @Test


### PR DESCRIPTION
To make it easier, and more consistent, for new contributors to the
project to write code that doesn't require style-related comments, we
can use the Spotless' Maven plugin to auto-format our code.

This uses the Google Java Code Style, which uses 2 spaces, not 4 as we
had previously, as well as adding our XML files to be consistently
formatted, too.

Closes #185.

---

[Whitespace-less diff](https://github.com/valfirst/slf4j-test/pull/186/files?diff=split&w=1)

Draft as I'm not sure this is quite what you'd expected, as this changes from 4 -> 2 spaces