### PR TITLE
Add assertions based on `LoggingEvent`

### DIFF
--- a/src/main/java/com/github/valfirst/slf4jtest/AbstractTestLoggerAssert.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/AbstractTestLoggerAssert.java
@@ -31,4 +31,39 @@ abstract class AbstractTestLoggerAssert<C extends AbstractAssert<C, TestLogger>>
                         && event.getArguments().equals(Arrays.asList(arguments))
                         && event.getThrowable().equals(maybeThrowable);
     }
+
+    protected static LoggingEvent event(Level level, String message, Object... arguments) {
+        switch (level) {
+            case WARN:
+                return LoggingEvent.warn(message, arguments);
+            case ERROR:
+                return LoggingEvent.error(message, arguments);
+            case INFO:
+                return LoggingEvent.info(message, arguments);
+            case DEBUG:
+                return LoggingEvent.debug(message, arguments);
+            case TRACE:
+                return LoggingEvent.trace(message, arguments);
+            default:
+                throw new IllegalStateException("Unmatched level " + level + " provided");
+        }
+    }
+
+    protected static LoggingEvent event(
+            Throwable throwable, Level level, String message, Object... arguments) {
+        switch (level) {
+            case WARN:
+                return LoggingEvent.warn(throwable, message, arguments);
+            case ERROR:
+                return LoggingEvent.error(throwable, message, arguments);
+            case INFO:
+                return LoggingEvent.info(throwable, message, arguments);
+            case DEBUG:
+                return LoggingEvent.debug(throwable, message, arguments);
+            case TRACE:
+                return LoggingEvent.trace(throwable, message, arguments);
+            default:
+                throw new IllegalStateException("Unmatched level " + level + " provided");
+        }
+    }
 }

--- a/src/main/java/com/github/valfirst/slf4jtest/TestLoggerAssert.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLoggerAssert.java
@@ -93,6 +93,12 @@ public class TestLoggerAssert extends AbstractTestLoggerAssert<TestLoggerAssert>
         return this;
     }
 
+    /**
+    * Convenience method for a {@link LevelAssert} from a provided test logger.
+    *
+    * @param level the {@link Level} to assert against
+    * @return the {@link LevelAssert} bound to the given {@link Level}
+    */
     public LevelAssert hasLevel(Level level) {
         return new LevelAssert(actual, level);
     }

--- a/src/main/java/com/github/valfirst/slf4jtest/TestLoggerAssert.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLoggerAssert.java
@@ -1,6 +1,5 @@
 package com.github.valfirst.slf4jtest;
 
-import java.util.Optional;
 import uk.org.lidalia.slf4jext.Level;
 
 /**
@@ -23,15 +22,7 @@ public class TestLoggerAssert extends AbstractTestLoggerAssert<TestLoggerAssert>
     * @return a {@link TestLoggerAssert} for chaining
     */
     public TestLoggerAssert hasLogged(Level level, String message, Object... arguments) {
-        long count = getLogCount(level, logWithMessage(message, arguments));
-        if (count == 0) {
-            if (arguments.length == 0) {
-                failWithMessage("Failed to find %s log with message `%s`", level, message);
-            } else {
-                failWithMessage("Failed to find %s log with message `%s` (with arguments)", level, message);
-            }
-        }
-        return this;
+        return hasLogged(event(level, message, arguments));
     }
 
     /**
@@ -46,16 +37,18 @@ public class TestLoggerAssert extends AbstractTestLoggerAssert<TestLoggerAssert>
     */
     public TestLoggerAssert hasLogged(
             Throwable throwable, Level level, String message, Object... arguments) {
-        long count = getLogCount(level, logWithMessage(message, Optional.of(throwable), arguments));
-        if (count == 0) {
-            if (arguments.length == 0) {
-                failWithMessage(
-                        "Failed to find %s log message with message `%s` (with throwable)", level, message);
-            } else {
-                failWithMessage(
-                        "Failed to find %s log message with message `%s` (with throwable and arguments)",
-                        level, message);
-            }
+        return hasLogged(event(throwable, level, message, arguments));
+    }
+
+    /**
+    * Verify that a {@link LoggingEvent} has been logged by the test logger.
+    *
+    * @param event the event to verify presence of
+    * @return a {@link TestLoggerAssert} for chaining
+    */
+    public TestLoggerAssert hasLogged(LoggingEvent event) {
+        if (!actual.getLoggingEvents().contains(event)) {
+            failWithMessage("Failed to find %s", event);
         }
         return this;
     }
@@ -69,18 +62,7 @@ public class TestLoggerAssert extends AbstractTestLoggerAssert<TestLoggerAssert>
     * @return a {@link TestLoggerAssert} for chaining
     */
     public TestLoggerAssert hasNotLogged(Level level, String message, Object... arguments) {
-        long count = getLogCount(level, logWithMessage(message, arguments));
-        if (count != 0) {
-            if (arguments.length == 0) {
-                failWithMessage(
-                        "Found %s log with message `%s`, even though we expected not to", level, message);
-            } else {
-                failWithMessage(
-                        "Found %s log with message `%s` (with arguments), even though we expected not to",
-                        level, message);
-            }
-        }
-        return this;
+        return hasNotLogged(event(level, message, arguments));
     }
 
     /**
@@ -95,17 +77,18 @@ public class TestLoggerAssert extends AbstractTestLoggerAssert<TestLoggerAssert>
     */
     public TestLoggerAssert hasNotLogged(
             Throwable throwable, Level level, String message, Object... arguments) {
-        long count = getLogCount(level, logWithMessage(message, Optional.of(throwable), arguments));
-        if (count != 0) {
-            if (arguments.length == 0) {
-                failWithMessage(
-                        "Found %s log with message `%s` (with throwable), even though we expected not to",
-                        level, message);
-            } else {
-                failWithMessage(
-                        "Found %s log with message `%s` (with throwable and arguments), even though we expected not to",
-                        level, message);
-            }
+        return hasNotLogged(event(throwable, level, message, arguments));
+    }
+
+    /**
+    * Verify that a {@link LoggingEvent} has not been logged by the test logger.
+    *
+    * @param event the event to verify absence of
+    * @return a {@link TestLoggerAssert} for chaining
+    */
+    public TestLoggerAssert hasNotLogged(LoggingEvent event) {
+        if (actual.getLoggingEvents().contains(event)) {
+            failWithMessage("Found %s, even though we expected not to", event);
         }
         return this;
     }

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
@@ -26,258 +26,297 @@ class TestLoggerAssertionsTest {
 
     @Nested
     class HasLogged {
-        @Test
-        void failsWhenLogMessageIsNotFound() {
-            when(logger.getLoggingEvents()).thenReturn(ImmutableList.of());
-
-            assertThatThrownBy(() -> assertions.hasLogged(Level.WARN, "Something may be wrong"))
-                    .isInstanceOf(AssertionError.class)
-                    .hasMessage("Failed to find WARN log with message `Something may be wrong`");
-        }
-
-        @Test
-        void failsWhenExpectingMoreArgumentsThanExists() {
-            when(logger.getLoggingEvents())
-                    .thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
-
-            assertThatThrownBy(
-                            () -> assertions.hasLogged(Level.WARN, "Something may be wrong", "Extra context"))
-                    .isInstanceOf(AssertionError.class)
-                    .hasMessage(
-                            "Failed to find WARN log with message `Something may be wrong` (with arguments)");
-        }
-
-        @Test
-        void failsWhenActuallyMoreArgumentsThanExpected() {
-            when(logger.getLoggingEvents())
-                    .thenReturn(
-                            ImmutableList.of(
-                                    LoggingEvent.warn("Something may be wrong", "Extra context", "Another")));
-
-            assertThatThrownBy(
-                            () -> assertions.hasLogged(Level.WARN, "Something may be wrong", "Extra context"))
-                    .isInstanceOf(AssertionError.class)
-                    .hasMessage(
-                            "Failed to find WARN log with message `Something may be wrong` (with arguments)");
-        }
-
-        @Test
-        void failsWhenArgumentsInDifferentOrder() {
-            when(logger.getLoggingEvents())
-                    .thenReturn(
-                            ImmutableList.of(
-                                    LoggingEvent.warn("Something may be wrong", "Another", "Extra context")));
-
-            assertThatThrownBy(
-                            () ->
-                                    assertions.hasLogged(
-                                            Level.WARN, "Something may be wrong", "Extra context", "Another"))
-                    .isInstanceOf(AssertionError.class)
-                    .hasMessage(
-                            "Failed to find WARN log with message `Something may be wrong` (with arguments)");
-        }
-
-        @Test
-        void passesWhenLogMessageIsFound() {
-            when(logger.getLoggingEvents())
-                    .thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
-
-            assertThatCode(() -> assertions.hasLogged(Level.WARN, "Something may be wrong"))
-                    .doesNotThrowAnyException();
-        }
-
-        @Test
-        void returnsSelfWhenPasses() {
-            when(logger.getLoggingEvents())
-                    .thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
-
-            TestLoggerAssert actual = assertions.hasLogged(Level.WARN, "Something may be wrong");
-
-            assertThat(actual).isNotNull();
-        }
 
         @Nested
-        class Throwables {
-            @Mock private Throwable throwable;
+        class LogMessage extends TestCase {
 
-            @Test
-            void canBeUsedToAssertWithThrowablesWhenFound() {
-                when(logger.getLoggingEvents())
-                        .thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!")));
-
-                assertThatCode(() -> assertions.hasLogged(throwable, Level.ERROR, "There was a problem!"))
-                        .doesNotThrowAnyException();
+            @Override
+            TestLoggerAssert performAssert(Level level, String message, Object... arguments) {
+                return assertions.hasLogged(level, message, arguments);
             }
 
-            @Test
-            void canBeUsedToAssertWithThrowablesWhenNotFoundWithArguments() {
-                when(logger.getLoggingEvents())
-                        .thenReturn(ImmutableList.of(LoggingEvent.error("There was a problem!", "context")));
+            @Override
+            TestLoggerAssert performAssert(
+                    Throwable throwable, Level level, String message, Object... arguments) {
+                return assertions.hasLogged(throwable, level, message, arguments);
+            }
+        }
 
-                assertThatThrownBy(
-                                () ->
-                                        assertions.hasLogged(throwable, Level.ERROR, "There was a problem!", "context"))
-                        .isInstanceOf(AssertionError.class)
-                        .hasMessage(
-                                "Failed to find ERROR log message with message `There was a problem!` (with throwable and arguments)");
+        abstract class TestCase {
+            abstract TestLoggerAssert performAssert(Level level, String message, Object... arguments);
+
+            abstract TestLoggerAssert performAssert(
+                    Throwable throwable, Level level, String message, Object... arguments);
+
+            @Nested
+            class WithoutThrowable {
+                @Test
+                void failsWhenLogMessageIsNotFound() {
+                    when(logger.getLoggingEvents()).thenReturn(ImmutableList.of());
+
+                    assertThatThrownBy(() -> performAssert(Level.WARN, "Something may be wrong"))
+                            .isInstanceOf(AssertionError.class)
+                            .hasMessage("Failed to find WARN log with message `Something may be wrong`");
+                }
+
+                @Test
+                void failsWhenExpectingMoreArgumentsThanExists() {
+                    when(logger.getLoggingEvents())
+                            .thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
+
+                    assertThatThrownBy(
+                                    () -> performAssert(Level.WARN, "Something may be wrong", "Extra context"))
+                            .isInstanceOf(AssertionError.class)
+                            .hasMessage(
+                                    "Failed to find WARN log with message `Something may be wrong` (with arguments)");
+                }
+
+                @Test
+                void failsWhenActuallyMoreArgumentsThanExpected() {
+                    when(logger.getLoggingEvents())
+                            .thenReturn(
+                                    ImmutableList.of(
+                                            LoggingEvent.warn("Something may be wrong", "Extra context", "Another")));
+
+                    assertThatThrownBy(
+                                    () -> performAssert(Level.WARN, "Something may be wrong", "Extra context"))
+                            .isInstanceOf(AssertionError.class)
+                            .hasMessage(
+                                    "Failed to find WARN log with message `Something may be wrong` (with arguments)");
+                }
+
+                @Test
+                void failsWhenArgumentsInDifferentOrder() {
+                    when(logger.getLoggingEvents())
+                            .thenReturn(
+                                    ImmutableList.of(
+                                            LoggingEvent.warn("Something may be wrong", "Another", "Extra context")));
+
+                    assertThatThrownBy(
+                                    () ->
+                                            performAssert(
+                                                    Level.WARN, "Something may be wrong", "Extra context", "Another"))
+                            .isInstanceOf(AssertionError.class)
+                            .hasMessage(
+                                    "Failed to find WARN log with message `Something may be wrong` (with arguments)");
+                }
+
+                @Test
+                void passesWhenLogMessageIsFound() {
+                    when(logger.getLoggingEvents())
+                            .thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
+
+                    assertThatCode(() -> performAssert(Level.WARN, "Something may be wrong"))
+                            .doesNotThrowAnyException();
+                }
+
+                @Test
+                void returnsSelfWhenPasses() {
+                    when(logger.getLoggingEvents())
+                            .thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
+
+                    TestLoggerAssert actual = performAssert(Level.WARN, "Something may be wrong");
+
+                    assertThat(actual).isNotNull();
+                }
             }
 
-            @Test
-            void canBeUsedToAssertWithThrowablesWhenNotFound() {
-                when(logger.getLoggingEvents())
-                        .thenReturn(ImmutableList.of(LoggingEvent.error("There was a problem!")));
+            @Nested
+            class Throwables {
+                @Mock private Throwable throwable;
 
-                assertThatThrownBy(
-                                () -> assertions.hasLogged(throwable, Level.ERROR, "There was a problem!"))
-                        .isInstanceOf(AssertionError.class)
-                        .hasMessage(
-                                "Failed to find ERROR log message with message `There was a problem!` (with throwable)");
-            }
+                @Test
+                void canBeUsedToAssertWithThrowablesWhenFound() {
+                    when(logger.getLoggingEvents())
+                            .thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!")));
 
-            @Test
-            void returnsSelfWhenPasses() {
-                when(logger.getLoggingEvents())
-                        .thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!")));
+                    assertThatCode(() -> performAssert(throwable, Level.ERROR, "There was a problem!"))
+                            .doesNotThrowAnyException();
+                }
 
-                TestLoggerAssert actual =
-                        assertions.hasLogged(throwable, Level.ERROR, "There was a problem!");
+                @Test
+                void canBeUsedToAssertWithThrowablesWhenNotFoundWithArguments() {
+                    when(logger.getLoggingEvents())
+                            .thenReturn(ImmutableList.of(LoggingEvent.error("There was a problem!", "context")));
 
-                assertThat(actual).isNotNull();
+                    assertThatThrownBy(
+                                    () -> performAssert(throwable, Level.ERROR, "There was a problem!", "context"))
+                            .isInstanceOf(AssertionError.class)
+                            .hasMessage(
+                                    "Failed to find ERROR log message with message `There was a problem!` (with throwable and arguments)");
+                }
+
+                @Test
+                void canBeUsedToAssertWithThrowablesWhenNotFound() {
+                    when(logger.getLoggingEvents())
+                            .thenReturn(ImmutableList.of(LoggingEvent.error("There was a problem!")));
+
+                    assertThatThrownBy(() -> performAssert(throwable, Level.ERROR, "There was a problem!"))
+                            .isInstanceOf(AssertionError.class)
+                            .hasMessage(
+                                    "Failed to find ERROR log message with message `There was a problem!` (with throwable)");
+                }
+
+                @Test
+                void returnsSelfWhenPasses() {
+                    when(logger.getLoggingEvents())
+                            .thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!")));
+
+                    TestLoggerAssert actual = performAssert(throwable, Level.ERROR, "There was a problem!");
+
+                    assertThat(actual).isNotNull();
+                }
             }
         }
     }
 
     @Nested
     class HasNotLogged {
-        @Test
-        void failsWhenLogMessageIsFound() {
-            when(logger.getLoggingEvents())
-                    .thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
-
-            assertThatThrownBy(() -> assertions.hasNotLogged(Level.WARN, "Something may be wrong"))
-                    .isInstanceOf(AssertionError.class)
-                    .hasMessage(
-                            "Found WARN log with message `Something may be wrong`, even though we expected not to");
-        }
-
-        @Test
-        void failsWhenExpectingMoreArgumentsThanExists() {
-            when(logger.getLoggingEvents())
-                    .thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
-
-            assertThatCode(
-                            () -> assertions.hasNotLogged(Level.WARN, "Something may be wrong", "Extra context"))
-                    .doesNotThrowAnyException();
-        }
-
-        @Test
-        void passesWhenActuallyMoreArgumentsThanExpected() {
-            when(logger.getLoggingEvents())
-                    .thenReturn(
-                            ImmutableList.of(
-                                    LoggingEvent.warn("Something may be wrong", "Extra context", "Another")));
-
-            assertThatCode(
-                            () -> assertions.hasNotLogged(Level.WARN, "Something may be wrong", "Extra context"))
-                    .doesNotThrowAnyException();
-        }
-
-        @Test
-        void failsWhenArgumentsInDifferentOrder() {
-            when(logger.getLoggingEvents())
-                    .thenReturn(
-                            ImmutableList.of(
-                                    LoggingEvent.warn("Something may be wrong", "Another", "Extra context")));
-
-            assertThatCode(
-                            () ->
-                                    assertions.hasNotLogged(
-                                            Level.WARN, "Something may be wrong", "Extra context", "Another"))
-                    .doesNotThrowAnyException();
-        }
-
-        @Test
-        void passesWhenLogMessageIsNotFound() {
-            when(logger.getLoggingEvents())
-                    .thenReturn(ImmutableList.of(LoggingEvent.info("Nothing to see here")));
-
-            assertThatCode(() -> assertions.hasNotLogged(Level.WARN, "Something may be wrong"))
-                    .doesNotThrowAnyException();
-        }
-
-        @Test
-        void passesWhenLogMessageIsNotFoundWithArguments() {
-            when(logger.getLoggingEvents())
-                    .thenReturn(
-                            ImmutableList.of(LoggingEvent.info("Nothing to see here", "Context setting")));
-
-            assertThatCode(() -> assertions.hasNotLogged(Level.WARN, "Something may be wrong"))
-                    .doesNotThrowAnyException();
-        }
-
-        @Test
-        void returnsSelfWhenPasses() {
-            when(logger.getLoggingEvents())
-                    .thenReturn(ImmutableList.of(LoggingEvent.warn("Something else")));
-
-            TestLoggerAssert actual = assertions.hasNotLogged(Level.WARN, "Something may be wrong");
-
-            assertThat(actual).isNotNull();
-        }
 
         @Nested
-        class Throwables {
-            @Mock private Throwable throwable;
+        class LogMessage extends TestCase {
+
+            @Override
+            TestLoggerAssert performAssert(Level level, String message, Object... arguments) {
+                return assertions.hasNotLogged(level, message, arguments);
+            }
+
+            @Override
+            TestLoggerAssert performAssert(
+                    Throwable throwable, Level level, String message, Object... arguments) {
+                return assertions.hasNotLogged(throwable, level, message, arguments);
+            }
+        }
+
+        abstract class TestCase {
+            abstract TestLoggerAssert performAssert(Level level, String message, Object... arguments);
+
+            abstract TestLoggerAssert performAssert(
+                    Throwable throwable, Level level, String message, Object... arguments);
 
             @Test
-            void canBeUsedToAssertWithThrowablesWhenNotFound() {
+            void failsWhenLogMessageIsFound() {
                 when(logger.getLoggingEvents())
-                        .thenReturn(
-                                ImmutableList.of(
-                                        LoggingEvent.error(
-                                                throwable,
-                                                "There was a problem, but this isn't what you're looking for!")));
+                        .thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
 
-                assertThatCode(
-                                () -> assertions.hasNotLogged(throwable, Level.ERROR, "There was a problem!"))
+                assertThatThrownBy(() -> performAssert(Level.WARN, "Something may be wrong"))
+                        .isInstanceOf(AssertionError.class)
+                        .hasMessage(
+                                "Found WARN log with message `Something may be wrong`, even though we expected not to");
+            }
+
+            @Test
+            void failsWhenExpectingMoreArgumentsThanExists() {
+                when(logger.getLoggingEvents())
+                        .thenReturn(ImmutableList.of(LoggingEvent.warn("Something may be wrong")));
+
+                assertThatCode(() -> performAssert(Level.WARN, "Something may be wrong", "Extra context"))
                         .doesNotThrowAnyException();
             }
 
             @Test
-            void canBeUsedToAssertWithThrowablesWhenFoundWithArguments() {
+            void passesWhenActuallyMoreArgumentsThanExpected() {
                 when(logger.getLoggingEvents())
                         .thenReturn(
-                                ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!", "context")));
+                                ImmutableList.of(
+                                        LoggingEvent.warn("Something may be wrong", "Extra context", "Another")));
 
-                assertThatThrownBy(
-                                () ->
-                                        assertions.hasNotLogged(
-                                                throwable, Level.ERROR, "There was a problem!", "context"))
-                        .isInstanceOf(AssertionError.class)
-                        .hasMessage(
-                                "Found ERROR log with message `There was a problem!` (with throwable and arguments), even though we expected not to");
+                assertThatCode(() -> performAssert(Level.WARN, "Something may be wrong", "Extra context"))
+                        .doesNotThrowAnyException();
             }
 
             @Test
-            void canBeUsedToAssertWithThrowablesWhenFound() {
+            void failsWhenArgumentsInDifferentOrder() {
                 when(logger.getLoggingEvents())
-                        .thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!")));
+                        .thenReturn(
+                                ImmutableList.of(
+                                        LoggingEvent.warn("Something may be wrong", "Another", "Extra context")));
 
-                assertThatThrownBy(
-                                () -> assertions.hasNotLogged(throwable, Level.ERROR, "There was a problem!"))
-                        .isInstanceOf(AssertionError.class)
-                        .hasMessage(
-                                "Found ERROR log with message `There was a problem!` (with throwable), even though we expected not to");
+                assertThatCode(
+                                () ->
+                                        performAssert(Level.WARN, "Something may be wrong", "Extra context", "Another"))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void passesWhenLogMessageIsNotFound() {
+                when(logger.getLoggingEvents())
+                        .thenReturn(ImmutableList.of(LoggingEvent.info("Nothing to see here")));
+
+                assertThatCode(() -> performAssert(Level.WARN, "Something may be wrong"))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void passesWhenLogMessageIsNotFoundWithArguments() {
+                when(logger.getLoggingEvents())
+                        .thenReturn(
+                                ImmutableList.of(LoggingEvent.info("Nothing to see here", "Context setting")));
+
+                assertThatCode(() -> performAssert(Level.WARN, "Something may be wrong"))
+                        .doesNotThrowAnyException();
             }
 
             @Test
             void returnsSelfWhenPasses() {
-                when(logger.getLoggingEvents()).thenReturn(ImmutableList.of());
+                when(logger.getLoggingEvents())
+                        .thenReturn(ImmutableList.of(LoggingEvent.warn("Something else")));
 
-                TestLoggerAssert actual =
-                        assertions.hasNotLogged(throwable, Level.ERROR, "There was a problem!");
+                TestLoggerAssert actual = performAssert(Level.WARN, "Something may be wrong");
 
                 assertThat(actual).isNotNull();
+            }
+
+            @Nested
+            class Throwables {
+                @Mock private Throwable throwable;
+
+                @Test
+                void canBeUsedToAssertWithThrowablesWhenNotFound() {
+                    when(logger.getLoggingEvents())
+                            .thenReturn(
+                                    ImmutableList.of(
+                                            LoggingEvent.error(
+                                                    throwable,
+                                                    "There was a problem, but this isn't what you're looking for!")));
+
+                    assertThatCode(() -> performAssert(throwable, Level.ERROR, "There was a problem!"))
+                            .doesNotThrowAnyException();
+                }
+
+                @Test
+                void canBeUsedToAssertWithThrowablesWhenFoundWithArguments() {
+                    when(logger.getLoggingEvents())
+                            .thenReturn(
+                                    ImmutableList.of(
+                                            LoggingEvent.error(throwable, "There was a problem!", "context")));
+
+                    assertThatThrownBy(
+                                    () -> performAssert(throwable, Level.ERROR, "There was a problem!", "context"))
+                            .isInstanceOf(AssertionError.class)
+                            .hasMessage(
+                                    "Found ERROR log with message `There was a problem!` (with throwable and arguments), even though we expected not to");
+                }
+
+                @Test
+                void canBeUsedToAssertWithThrowablesWhenFound() {
+                    when(logger.getLoggingEvents())
+                            .thenReturn(ImmutableList.of(LoggingEvent.error(throwable, "There was a problem!")));
+
+                    assertThatThrownBy(() -> performAssert(throwable, Level.ERROR, "There was a problem!"))
+                            .isInstanceOf(AssertionError.class)
+                            .hasMessage(
+                                    "Found ERROR log with message `There was a problem!` (with throwable), even though we expected not to");
+                }
+
+                @Test
+                void returnsSelfWhenPasses() {
+                    when(logger.getLoggingEvents()).thenReturn(ImmutableList.of());
+
+                    TestLoggerAssert actual = performAssert(throwable, Level.ERROR, "There was a problem!");
+
+                    assertThat(actual).isNotNull();
+                }
             }
         }
     }

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
@@ -42,6 +42,21 @@ class TestLoggerAssertionsTest {
             }
         }
 
+        @Nested
+        class AsLoggingEvent extends TestCase {
+
+            @Override
+            TestLoggerAssert performAssert(Level level, String message, Object... arguments) {
+                return assertions.hasLogged(event(level, message, arguments));
+            }
+
+            @Override
+            TestLoggerAssert performAssert(
+                    Throwable throwable, Level level, String message, Object... arguments) {
+                return assertions.hasLogged(event(throwable, level, message, arguments));
+            }
+        }
+
         abstract class TestCase {
             abstract TestLoggerAssert performAssert(Level level, String message, Object... arguments);
 
@@ -56,7 +71,8 @@ class TestLoggerAssertionsTest {
 
                     assertThatThrownBy(() -> performAssert(Level.WARN, "Something may be wrong"))
                             .isInstanceOf(AssertionError.class)
-                            .hasMessage("Failed to find WARN log with message `Something may be wrong`");
+                            .hasMessage(
+                                    "Failed to find LoggingEvent{level=WARN, mdc={}, marker=Optional.empty, throwable=Optional.empty, message='Something may be wrong', arguments=[]}");
                 }
 
                 @Test
@@ -68,7 +84,7 @@ class TestLoggerAssertionsTest {
                                     () -> performAssert(Level.WARN, "Something may be wrong", "Extra context"))
                             .isInstanceOf(AssertionError.class)
                             .hasMessage(
-                                    "Failed to find WARN log with message `Something may be wrong` (with arguments)");
+                                    "Failed to find LoggingEvent{level=WARN, mdc={}, marker=Optional.empty, throwable=Optional.empty, message='Something may be wrong', arguments=[Extra context]}");
                 }
 
                 @Test
@@ -82,7 +98,7 @@ class TestLoggerAssertionsTest {
                                     () -> performAssert(Level.WARN, "Something may be wrong", "Extra context"))
                             .isInstanceOf(AssertionError.class)
                             .hasMessage(
-                                    "Failed to find WARN log with message `Something may be wrong` (with arguments)");
+                                    "Failed to find LoggingEvent{level=WARN, mdc={}, marker=Optional.empty, throwable=Optional.empty, message='Something may be wrong', arguments=[Extra context]}");
                 }
 
                 @Test
@@ -98,7 +114,7 @@ class TestLoggerAssertionsTest {
                                                     Level.WARN, "Something may be wrong", "Extra context", "Another"))
                             .isInstanceOf(AssertionError.class)
                             .hasMessage(
-                                    "Failed to find WARN log with message `Something may be wrong` (with arguments)");
+                                    "Failed to find LoggingEvent{level=WARN, mdc={}, marker=Optional.empty, throwable=Optional.empty, message='Something may be wrong', arguments=[Extra context, Another]}");
                 }
 
                 @Test
@@ -143,7 +159,7 @@ class TestLoggerAssertionsTest {
                                     () -> performAssert(throwable, Level.ERROR, "There was a problem!", "context"))
                             .isInstanceOf(AssertionError.class)
                             .hasMessage(
-                                    "Failed to find ERROR log message with message `There was a problem!` (with throwable and arguments)");
+                                    "Failed to find LoggingEvent{level=ERROR, mdc={}, marker=Optional.empty, throwable=Optional[throwable], message='There was a problem!', arguments=[context]}");
                 }
 
                 @Test
@@ -154,7 +170,7 @@ class TestLoggerAssertionsTest {
                     assertThatThrownBy(() -> performAssert(throwable, Level.ERROR, "There was a problem!"))
                             .isInstanceOf(AssertionError.class)
                             .hasMessage(
-                                    "Failed to find ERROR log message with message `There was a problem!` (with throwable)");
+                                    "Failed to find LoggingEvent{level=ERROR, mdc={}, marker=Optional.empty, throwable=Optional[throwable], message='There was a problem!', arguments=[]}");
                 }
 
                 @Test
@@ -188,6 +204,21 @@ class TestLoggerAssertionsTest {
             }
         }
 
+        @Nested
+        class AsLoggingEvent extends TestCase {
+
+            @Override
+            TestLoggerAssert performAssert(Level level, String message, Object... arguments) {
+                return assertions.hasNotLogged(event(level, message, arguments));
+            }
+
+            @Override
+            TestLoggerAssert performAssert(
+                    Throwable throwable, Level level, String message, Object... arguments) {
+                return assertions.hasNotLogged(event(throwable, level, message, arguments));
+            }
+        }
+
         abstract class TestCase {
             abstract TestLoggerAssert performAssert(Level level, String message, Object... arguments);
 
@@ -202,7 +233,7 @@ class TestLoggerAssertionsTest {
                 assertThatThrownBy(() -> performAssert(Level.WARN, "Something may be wrong"))
                         .isInstanceOf(AssertionError.class)
                         .hasMessage(
-                                "Found WARN log with message `Something may be wrong`, even though we expected not to");
+                                "Found LoggingEvent{level=WARN, mdc={}, marker=Optional.empty, throwable=Optional.empty, message='Something may be wrong', arguments=[]}, even though we expected not to");
             }
 
             @Test
@@ -295,7 +326,7 @@ class TestLoggerAssertionsTest {
                                     () -> performAssert(throwable, Level.ERROR, "There was a problem!", "context"))
                             .isInstanceOf(AssertionError.class)
                             .hasMessage(
-                                    "Found ERROR log with message `There was a problem!` (with throwable and arguments), even though we expected not to");
+                                    "Found LoggingEvent{level=ERROR, mdc={}, marker=Optional.empty, throwable=Optional[throwable], message='There was a problem!', arguments=[context]}, even though we expected not to");
                 }
 
                 @Test
@@ -306,7 +337,7 @@ class TestLoggerAssertionsTest {
                     assertThatThrownBy(() -> performAssert(throwable, Level.ERROR, "There was a problem!"))
                             .isInstanceOf(AssertionError.class)
                             .hasMessage(
-                                    "Found ERROR log with message `There was a problem!` (with throwable), even though we expected not to");
+                                    "Found LoggingEvent{level=ERROR, mdc={}, marker=Optional.empty, throwable=Optional[throwable], message='There was a problem!', arguments=[]}, even though we expected not to");
                 }
 
                 @Test
@@ -328,6 +359,41 @@ class TestLoggerAssertionsTest {
             LevelAssert actual = assertions.hasLevel(Level.ERROR);
 
             assertThat(actual).isNotNull();
+        }
+    }
+
+    private static LoggingEvent event(Level level, String message, Object... arguments) {
+        switch (level) {
+            case WARN:
+                return LoggingEvent.warn(message, arguments);
+            case ERROR:
+                return LoggingEvent.error(message, arguments);
+            case INFO:
+                return LoggingEvent.info(message, arguments);
+            case DEBUG:
+                return LoggingEvent.debug(message, arguments);
+            case TRACE:
+                return LoggingEvent.trace(message, arguments);
+            default:
+                throw new IllegalStateException("Unmatched level " + level + " provided");
+        }
+    }
+
+    private static LoggingEvent event(
+            Throwable throwable, Level level, String message, Object... arguments) {
+        switch (level) {
+            case WARN:
+                return LoggingEvent.warn(throwable, message, arguments);
+            case ERROR:
+                return LoggingEvent.error(throwable, message, arguments);
+            case INFO:
+                return LoggingEvent.info(throwable, message, arguments);
+            case DEBUG:
+                return LoggingEvent.debug(throwable, message, arguments);
+            case TRACE:
+                return LoggingEvent.trace(throwable, message, arguments);
+            default:
+                throw new IllegalStateException("Unmatched level " + level + " provided");
         }
     }
 }


### PR DESCRIPTION
Asserting based on a `LoggingEvent` is actually a simpler API, and so
we should make it possible to use this, as well as the existing methods
we have available.

This requires we provide a helper to map the `Level` to a `LoggingEvent`
with its arguments.

We can replace `TestLoggerAssert`'s methods with the new
`LoggingEvent`-based methods, as they are much clearer for their intent.

This also tweaks the error messages for failed assertions to utilise
`LoggingEvent.toString()`, as it provides a readable, descriptive
explanation of what was/wasn't available.

Also:

- Use abstract test classes in `TestLoggerAssertionsTest`
- Add missing JavaDoc for `hasLevel` method
