### PR TITLE
Enable assertions to be made on `LoggingEvent`s from any thread.

### DIFF
--- a/src/main/java/com/github/valfirst/slf4jtest/AbstractTestLoggerAssert.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/AbstractTestLoggerAssert.java
@@ -1,19 +1,24 @@
 package com.github.valfirst.slf4jtest;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import org.assertj.core.api.AbstractAssert;
 import uk.org.lidalia.slf4jext.Level;
 
 abstract class AbstractTestLoggerAssert<C extends AbstractAssert<C, TestLogger>>
         extends AbstractAssert<C, TestLogger> {
+    protected Supplier<List<LoggingEvent>> loggingEventsSupplier;
+
     protected AbstractTestLoggerAssert(TestLogger testLogger, Class clazz) {
         super(testLogger, clazz);
+        loggingEventsSupplier = testLogger::getLoggingEvents;
     }
 
     protected long getLogCount(Level level, Predicate<LoggingEvent> predicate) {
-        return actual.getLoggingEvents().stream()
+        return loggingEventsSupplier.get().stream()
                 .filter(event -> level.equals(event.getLevel()) && predicate.test(event))
                 .count();
     }


### PR DESCRIPTION
The current implementation only verifies against the `LoggingEvent`s captured by the thread that is running the test. `TestLogger` provides access to all events captured across any thread via `TestLogger::getAllLoggingEvents()` so a modifying method has been added to the assertion class to allow the assertion mode to be switched.

Example usage:

```
assertThat(logger).anyThread().hasLogged(...);
```