### PR TITLE
Format nulls like slf4j

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ all available from Maven Central.
 </dependency>
 ```
 
-## Compatiblity Matrix
+## Compatibility Matrix
 |`org.slf4j:slf4j-api`            | `com.github.valfirst:slf4j-test` |
 |---------------------------------|----------------------------------| 
 | `1.8.0-beta0` - `2.0.0-alpha2`  | `1.3.0` - `2.3.0`                |
@@ -51,7 +51,7 @@ SLF4J Test supports automatic extension registration via ServiceLoader mechanism
 ## Credits
 This project is based on the original implementation by [Robert Elliot](https://github.com/Mahoney), located at https://github.com/Mahoney/slf4j-test which worked with SLF4J prior to version 1.8.X.
 
-See http://projects.lidalia.org.uk/slf4j-test for details.
+See https://projects.lidalia.org.uk/slf4j-test for details.
 
 
 ## License Scan

--- a/src/main/java/com/github/valfirst/slf4jtest/LoggingEvent.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/LoggingEvent.java
@@ -476,7 +476,9 @@ public class LoggingEvent {
     }
 
     public String getFormattedMessage() {
-        return MessageFormatter.arrayFormat(getMessage(), getArguments().toArray()).getMessage();
+        Object[] argumentsWithNulls =
+                getArguments().stream().map(a -> a.equals(Optional.empty()) ? null : a).toArray();
+        return MessageFormatter.arrayFormat(getMessage(), argumentsWithNulls).getMessage();
     }
 
     private PrintStream printStreamForLevel() {

--- a/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
@@ -491,6 +491,12 @@ class LoggingEventTests extends StdIoTests {
         assertThat(event, is(new LoggingEvent(level, "message with null arg", empty(), empty())));
     }
 
+    @Test
+    public void nullArgumentIsFormattedLikeSlf4j() {
+        LoggingEvent event = new LoggingEvent(level, "message with {}, {}", null, "value");
+        assertThat(event.getFormattedMessage(), is("message with null, value"));
+    }
+
     public interface TriFunction<A, B, C, R> {
         R apply(A a, B b, C c);
     }


### PR DESCRIPTION
A simple fix for #220 . There's an edge case here, if `empty()` were passed as an argument, but any fix for that would be more disruptive.

Fixes #220.