### PR TITLE
Adding TCCL attribute to LoggingEvent

### DIFF
--- a/src/main/java/com/github/valfirst/slf4jtest/LoggingEvent.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/LoggingEvent.java
@@ -32,8 +32,8 @@ import uk.org.lidalia.slf4jext.Level;
  * </ul>
  *
  * <p>They do NOT compare the results of {@link #getTimestamp()}, {@link #getCreatingLogger()} or
- * {@link #getThreadContextClassLoader()} ()} as this would render it impractical to create
- * appropriate expected {@link LoggingEvent}s to compare against.
+ * {@link #getThreadContextClassLoader()} as this would render it impractical to create appropriate
+ * expected {@link LoggingEvent}s to compare against.
  *
  * <p>Constructors and convenient static factory methods exist to create {@link LoggingEvent}s with
  * appropriate defaults. These are not documented further as they should be self-evident.

--- a/src/main/java/com/github/valfirst/slf4jtest/LoggingEvent.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/LoggingEvent.java
@@ -31,9 +31,9 @@ import uk.org.lidalia.slf4jext.Level;
  *   <li>{@link #getArguments()}
  * </ul>
  *
- * <p>They do NOT compare the results of {@link #getTimestamp()} or {@link #getCreatingLogger()} as
- * this would render it impractical to create appropriate expected {@link LoggingEvent}s to compare
- * against.
+ * <p>They do NOT compare the results of {@link #getTimestamp()}, {@link #getCreatingLogger()} or
+ * {@link #getThreadContextClassLoader()} ()} as this would render it impractical to create
+ * appropriate expected {@link LoggingEvent}s to compare against.
  *
  * <p>Constructors and convenient static factory methods exist to create {@link LoggingEvent}s with
  * appropriate defaults. These are not documented further as they should be self-evident.
@@ -51,6 +51,8 @@ public class LoggingEvent {
     private final Optional<TestLogger> creatingLogger;
     private final Instant timestamp = new Instant();
     private final String threadName = Thread.currentThread().getName();
+    private final ClassLoader threadContextClassLoader =
+            Thread.currentThread().getContextClassLoader();
 
     public static LoggingEvent trace(final String message, final Object... arguments) {
         return new LoggingEvent(Level.TRACE, message, arguments);
@@ -452,6 +454,11 @@ public class LoggingEvent {
     /** @return the name of the thread that created this logging event */
     public String getThreadName() {
         return threadName;
+    }
+
+    /** @return the Thread Context Classloader used when this logging event was created */
+    public ClassLoader getThreadContextClassLoader() {
+        return threadContextClassLoader;
     }
 
     void print() {

--- a/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
@@ -154,7 +154,7 @@ class LoggingEventTests extends StdIoTests {
 
     @Test
     void constructorAndCheckThreadContextClassloader() {
-        LoggingEvent event = new LoggingEvent(level, mdc, marker, throwable, message, arg1, arg2);
+        LoggingEvent event = new LoggingEvent(level, mdc, marker, throwable, message, arg1);
         assertThat(
                 event.getThreadContextClassLoader(), is(Thread.currentThread().getContextClassLoader()));
     }

--- a/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
@@ -152,6 +152,19 @@ class LoggingEventTests extends StdIoTests {
         assertThat(event.getArguments(), is(args));
     }
 
+    @Test
+    void constructorThreadContextClassloader() {
+        LoggingEvent event = new LoggingEvent(level, mdc, marker, throwable, message, arg1, arg2);
+        assertThat(event.getLevel(), is(level));
+        assertThat(event.getMdc(), is(mdc));
+        assertThat(event.getMarker(), is(of(marker)));
+        assertThat(event.getThrowable(), is(of(throwable)));
+        assertThat(event.getMessage(), is(message));
+        assertThat(event.getArguments(), is(args));
+        assertThat(
+                event.getThreadContextClassLoader(), is(Thread.currentThread().getContextClassLoader()));
+    }
+
     static Stream<Arguments> messageArgs() {
         return Stream.of(
                 arguments((BiFunction<String, Object[], LoggingEvent>) LoggingEvent::trace, TRACE),

--- a/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
@@ -153,14 +153,8 @@ class LoggingEventTests extends StdIoTests {
     }
 
     @Test
-    void constructorThreadContextClassloader() {
+    void constructorAndCheckThreadContextClassloader() {
         LoggingEvent event = new LoggingEvent(level, mdc, marker, throwable, message, arg1, arg2);
-        assertThat(event.getLevel(), is(level));
-        assertThat(event.getMdc(), is(mdc));
-        assertThat(event.getMarker(), is(of(marker)));
-        assertThat(event.getThrowable(), is(of(throwable)));
-        assertThat(event.getMessage(), is(message));
-        assertThat(event.getArguments(), is(args));
         assertThat(
                 event.getThreadContextClassLoader(), is(Thread.currentThread().getContextClassLoader()));
     }


### PR DESCRIPTION
Adds an attribute on LoggingEvent which contains the Thread Context Classloader used when the logging event was created. This allows the assertion of the TCCL of a certain log to check that the log was handled by the correct classloader.

Closes #250 