### PR TITLE
Going back to custom uk.org.lidalia.lang.ThreadLocal in some classes

### DIFF
--- a/src/main/java/com/github/valfirst/slf4jtest/TestLogger.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLogger.java
@@ -57,7 +57,7 @@ public class TestLogger implements Logger {
 
     private final List<LoggingEvent> allLoggingEvents = new CopyOnWriteArrayList<>();
     private volatile ThreadLocal<ImmutableSet<Level>> enabledLevels =
-        new ThreadLocal<>(enablableValueSet());
+            new ThreadLocal<>(enablableValueSet());
 
     TestLogger(final String name, final TestLoggerFactory testLoggerFactory) {
         this.name = name;
@@ -145,7 +145,7 @@ public class TestLogger implements Logger {
 
     @Override
     public void trace(
-        final Marker marker, final String format, final Object arg1, final Object arg2) {
+            final Marker marker, final String format, final Object arg1, final Object arg2) {
         log(TRACE, marker, format, arg1, arg2);
     }
 
@@ -207,7 +207,7 @@ public class TestLogger implements Logger {
 
     @Override
     public void debug(
-        final Marker marker, final String format, final Object arg1, final Object arg2) {
+            final Marker marker, final String format, final Object arg1, final Object arg2) {
         log(DEBUG, marker, format, arg1, arg2);
     }
 
@@ -391,7 +391,7 @@ public class TestLogger implements Logger {
 
     @Override
     public void error(
-        final Marker marker, final String format, final Object arg1, final Object arg2) {
+            final Marker marker, final String format, final Object arg1, final Object arg2) {
         log(ERROR, marker, format, arg1, arg2);
     }
 
@@ -410,42 +410,42 @@ public class TestLogger implements Logger {
     }
 
     private void log(
-        final Level level,
-        final String msg,
-        final Throwable throwable) { // NOPMD PMD wrongly thinks unused...
+            final Level level,
+            final String msg,
+            final Throwable throwable) { // NOPMD PMD wrongly thinks unused...
         addLoggingEvent(level, Optional.empty(), ofNullable(throwable), msg);
     }
 
     private void log(
-        final Level level, final Marker marker, final String format, final Object... args) {
+            final Level level, final Marker marker, final String format, final Object... args) {
         log(level, format, ofNullable(marker), args);
     }
 
     private void log(
-        final Level level, final Marker marker, final String msg, final Throwable throwable) {
+            final Level level, final Marker marker, final String msg, final Throwable throwable) {
         addLoggingEvent(level, ofNullable(marker), ofNullable(throwable), msg);
     }
 
     private void log(
-        final Level level, final String format, final Optional<Marker> marker, final Object[] args) {
+            final Level level, final String format, final Optional<Marker> marker, final Object[] args) {
         final FormattingTuple formattedArgs = MessageFormatter.arrayFormat(format, args);
         addLoggingEvent(
-            level,
-            marker,
-            ofNullable(formattedArgs.getThrowable()),
-            format,
-            formattedArgs.getArgArray());
+                level,
+                marker,
+                ofNullable(formattedArgs.getThrowable()),
+                format,
+                formattedArgs.getArgArray());
     }
 
     private void addLoggingEvent(
-        final Level level,
-        final Optional<Marker> marker,
-        final Optional<Throwable> throwable,
-        final String format,
-        final Object... args) {
+            final Level level,
+            final Optional<Marker> marker,
+            final Optional<Throwable> throwable,
+            final String format,
+            final Object... args) {
         if (enabledLevels.get().contains(level)) {
             final LoggingEvent event =
-                new LoggingEvent(of(this), level, mdc(), marker, throwable, format, args);
+                    new LoggingEvent(of(this), level, mdc(), marker, throwable, format, args);
             allLoggingEvents.add(event);
             loggingEvents.get().add(event);
             testLoggerFactory.addLoggingEvent(event);

--- a/src/main/java/com/github/valfirst/slf4jtest/TestLoggerFactory.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLoggerFactory.java
@@ -22,25 +22,25 @@ import uk.org.lidalia.slf4jext.Level;
 public final class TestLoggerFactory implements ILoggerFactory {
 
     private static final Supplier<TestLoggerFactory> INSTANCE =
-        Suppliers.memoize(
-            () -> {
-                try {
-                    final String level =
-                        new OverridableProperties("slf4jtest").getProperty("print.level", "OFF");
-                    return new TestLoggerFactory(Level.valueOf(level));
-                } catch (IllegalArgumentException e) {
-                    throw new IllegalStateException(
-                        "Invalid level name in property print.level of file slf4jtest.properties "
-                            + "or System property slf4jtest.print.level",
-                        e);
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-            });
+            Suppliers.memoize(
+                    () -> {
+                        try {
+                            final String level =
+                                    new OverridableProperties("slf4jtest").getProperty("print.level", "OFF");
+                            return new TestLoggerFactory(Level.valueOf(level));
+                        } catch (IllegalArgumentException e) {
+                            throw new IllegalStateException(
+                                    "Invalid level name in property print.level of file slf4jtest.properties "
+                                            + "or System property slf4jtest.print.level",
+                                    e);
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    });
 
     private final ConcurrentMap<String, TestLogger> loggers = new ConcurrentHashMap<>();
     private final List<LoggingEvent> allLoggingEvents =
-        Collections.synchronizedList(new ArrayList<>());
+            Collections.synchronizedList(new ArrayList<>());
     private final ThreadLocal<List<LoggingEvent>> loggingEvents = new ThreadLocal<>(ArrayList::new);
     private volatile Level printLevel;
 

--- a/src/main/java/com/github/valfirst/slf4jtest/TestLoggerFactory.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLoggerFactory.java
@@ -16,31 +16,32 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 import org.slf4j.ILoggerFactory;
+import uk.org.lidalia.lang.ThreadLocal;
 import uk.org.lidalia.slf4jext.Level;
 
 public final class TestLoggerFactory implements ILoggerFactory {
 
     private static final Supplier<TestLoggerFactory> INSTANCE =
-            Suppliers.memoize(
-                    () -> {
-                        try {
-                            final String level =
-                                    new OverridableProperties("slf4jtest").getProperty("print.level", "OFF");
-                            return new TestLoggerFactory(Level.valueOf(level));
-                        } catch (IllegalArgumentException e) {
-                            throw new IllegalStateException(
-                                    "Invalid level name in property print.level of file slf4jtest.properties "
-                                            + "or System property slf4jtest.print.level",
-                                    e);
-                        } catch (IOException e) {
-                            throw new UncheckedIOException(e);
-                        }
-                    });
+        Suppliers.memoize(
+            () -> {
+                try {
+                    final String level =
+                        new OverridableProperties("slf4jtest").getProperty("print.level", "OFF");
+                    return new TestLoggerFactory(Level.valueOf(level));
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalStateException(
+                        "Invalid level name in property print.level of file slf4jtest.properties "
+                            + "or System property slf4jtest.print.level",
+                        e);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
 
     private final ConcurrentMap<String, TestLogger> loggers = new ConcurrentHashMap<>();
     private final List<LoggingEvent> allLoggingEvents =
-            Collections.synchronizedList(new ArrayList<>());
-    private ThreadLocal<List<LoggingEvent>> loggingEvents = ThreadLocal.withInitial(ArrayList::new);
+        Collections.synchronizedList(new ArrayList<>());
+    private final ThreadLocal<List<LoggingEvent>> loggingEvents = new ThreadLocal<>(ArrayList::new);
     private volatile Level printLevel;
 
     public static TestLoggerFactory getInstance() {
@@ -115,7 +116,7 @@ public final class TestLoggerFactory implements ILoggerFactory {
         for (final TestLogger testLogger : loggers.values()) {
             testLogger.clearAll();
         }
-        loggingEvents = ThreadLocal.withInitial(ArrayList::new);
+        loggingEvents.reset();
         allLoggingEvents.clear();
     }
 

--- a/src/main/java/uk/org/lidalia/lang/ThreadLocal.java
+++ b/src/main/java/uk/org/lidalia/lang/ThreadLocal.java
@@ -1,0 +1,89 @@
+package uk.org.lidalia.lang;
+
+import static java.lang.Thread.currentThread;
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.ofNullable;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * This class was written by Robert Elliot and is originally located at
+ * https://github.com/Mahoney/lidalia-lang
+ *
+ * <p>A ThreadLocal that has no {@link ClassLoader} leaks associated with it and does not permit
+ * null.
+ *
+ * <p>Values for all {@link Thread}s can be reset from any {@link Thread}.
+ *
+ * @param <T> the type of the thread local variable
+ */
+public class ThreadLocal<T> {
+
+  private final Map<Thread, T> contents = new ConcurrentHashMap<>();
+  private final Supplier<T> initialValueCreator;
+  private final Supplier<T> threadValueInitialiser =
+      new Supplier<T>() {
+        @Override
+        public T get() {
+          final T initialValue = initialValueCreator.get();
+          set(initialValue);
+          return initialValue;
+        }
+      };
+
+  /**
+   * @param initialValue the value this thread local will initially have for all {@link Thread}s.
+   *     This should not be mutable, as it will be shared between all {@link Thread}s.
+   */
+  public ThreadLocal(final T initialValue) {
+    this(() -> requireNonNull(initialValue));
+  }
+
+  /**
+   * @param initialValueCreator a {@link Supplier} whose get method is called on a per {@link
+   *     Thread} basis in order to establish the initial value for that {@link Thread}, allowing a
+   *     different initial instance per {@link Thread}.
+   */
+  public ThreadLocal(final Supplier<T> initialValueCreator) {
+    this.initialValueCreator = requireNonNull(initialValueCreator);
+  }
+
+  /**
+   * @param value the new value for the calling {@link Thread} - does not affect the value for any
+   *     other {@link Thread}.
+   */
+  public void set(final T value) {
+    contents.put(currentThread(), requireNonNull(value));
+  }
+
+  /**
+   * @return the value for the calling {@link Thread}, or the initial value if this has not been set
+   *     or has been removed.
+   */
+  public T get() {
+    return ofNullable(contents.get(currentThread())).orElseGet(threadValueInitialiser);
+  }
+
+  /**
+   * Removes the value for the calling {@link Thread}. A subsequent call to {@link #get()} will
+   * return the initial value.
+   */
+  public void remove() {
+    contents.remove(currentThread());
+  }
+
+  /**
+   * Removes the values for ALL {@link Thread}s. Subsequent calls to {@link #get()} will return the
+   * initial value.
+   */
+  public void reset() {
+    contents.clear();
+  }
+
+  public Collection<T> allValues() {
+    return contents.values();
+  }
+}

--- a/src/main/java/uk/org/lidalia/lang/ThreadLocal.java
+++ b/src/main/java/uk/org/lidalia/lang/ThreadLocal.java
@@ -22,68 +22,68 @@ import java.util.function.Supplier;
  */
 public class ThreadLocal<T> {
 
-  private final Map<Thread, T> contents = new ConcurrentHashMap<>();
-  private final Supplier<T> initialValueCreator;
-  private final Supplier<T> threadValueInitialiser =
-      new Supplier<T>() {
-        @Override
-        public T get() {
-          final T initialValue = initialValueCreator.get();
-          set(initialValue);
-          return initialValue;
-        }
-      };
+    private final Map<Thread, T> contents = new ConcurrentHashMap<>();
+    private final Supplier<T> initialValueCreator;
+    private final Supplier<T> threadValueInitialiser =
+            new Supplier<T>() {
+                @Override
+                public T get() {
+                    final T initialValue = initialValueCreator.get();
+                    set(initialValue);
+                    return initialValue;
+                }
+            };
 
-  /**
-   * @param initialValue the value this thread local will initially have for all {@link Thread}s.
-   *     This should not be mutable, as it will be shared between all {@link Thread}s.
-   */
-  public ThreadLocal(final T initialValue) {
-    this(() -> requireNonNull(initialValue));
-  }
+    /**
+     * @param initialValue the value this thread local will initially have for all {@link Thread}s.
+     *     This should not be mutable, as it will be shared between all {@link Thread}s.
+     */
+    public ThreadLocal(final T initialValue) {
+        this(() -> requireNonNull(initialValue));
+    }
 
-  /**
-   * @param initialValueCreator a {@link Supplier} whose get method is called on a per {@link
-   *     Thread} basis in order to establish the initial value for that {@link Thread}, allowing a
-   *     different initial instance per {@link Thread}.
-   */
-  public ThreadLocal(final Supplier<T> initialValueCreator) {
-    this.initialValueCreator = requireNonNull(initialValueCreator);
-  }
+    /**
+     * @param initialValueCreator a {@link Supplier} whose get method is called on a per {@link
+     *     Thread} basis in order to establish the initial value for that {@link Thread}, allowing a
+     *     different initial instance per {@link Thread}.
+     */
+    public ThreadLocal(final Supplier<T> initialValueCreator) {
+        this.initialValueCreator = requireNonNull(initialValueCreator);
+    }
 
-  /**
-   * @param value the new value for the calling {@link Thread} - does not affect the value for any
-   *     other {@link Thread}.
-   */
-  public void set(final T value) {
-    contents.put(currentThread(), requireNonNull(value));
-  }
+    /**
+     * @param value the new value for the calling {@link Thread} - does not affect the value for any
+     *     other {@link Thread}.
+     */
+    public void set(final T value) {
+        contents.put(currentThread(), requireNonNull(value));
+    }
 
-  /**
-   * @return the value for the calling {@link Thread}, or the initial value if this has not been set
-   *     or has been removed.
-   */
-  public T get() {
-    return ofNullable(contents.get(currentThread())).orElseGet(threadValueInitialiser);
-  }
+    /**
+     * @return the value for the calling {@link Thread}, or the initial value if this has not been set
+     *     or has been removed.
+     */
+    public T get() {
+        return ofNullable(contents.get(currentThread())).orElseGet(threadValueInitialiser);
+    }
 
-  /**
-   * Removes the value for the calling {@link Thread}. A subsequent call to {@link #get()} will
-   * return the initial value.
-   */
-  public void remove() {
-    contents.remove(currentThread());
-  }
+    /**
+     * Removes the value for the calling {@link Thread}. A subsequent call to {@link #get()} will
+     * return the initial value.
+     */
+    public void remove() {
+        contents.remove(currentThread());
+    }
 
-  /**
-   * Removes the values for ALL {@link Thread}s. Subsequent calls to {@link #get()} will return the
-   * initial value.
-   */
-  public void reset() {
-    contents.clear();
-  }
+    /**
+     * Removes the values for ALL {@link Thread}s. Subsequent calls to {@link #get()} will return the
+     * initial value.
+     */
+    public void reset() {
+        contents.clear();
+    }
 
-  public Collection<T> allValues() {
-    return contents.values();
-  }
+    public Collection<T> allValues() {
+        return contents.values();
+    }
 }

--- a/src/test/java/uk/org/lidalia/lang/ThreadLocalTests.java
+++ b/src/test/java/uk/org/lidalia/lang/ThreadLocalTests.java
@@ -12,125 +12,125 @@ import org.junit.Test;
  */
 public class ThreadLocalTests {
 
-  @Test
-  public void differentValuePerThread() throws InterruptedException {
-    final ThreadLocal<String> threadLocal = new ThreadLocal<>("Initial");
-    final AtomicReference<String> fromThread = new AtomicReference<>();
-    threadLocal.set("Thread1");
+    @Test
+    public void differentValuePerThread() throws InterruptedException {
+        final ThreadLocal<String> threadLocal = new ThreadLocal<>("Initial");
+        final AtomicReference<String> fromThread = new AtomicReference<>();
+        threadLocal.set("Thread1");
 
-    Thread thread =
-        new Thread(
-            () -> {
-              threadLocal.set("Thread2");
-              fromThread.set(threadLocal.get());
-            });
-    thread.start();
-    thread.join();
+        Thread thread =
+                new Thread(
+                        () -> {
+                            threadLocal.set("Thread2");
+                            fromThread.set(threadLocal.get());
+                        });
+        thread.start();
+        thread.join();
 
-    assertThat(threadLocal.get(), is("Thread1"));
-    assertThat(fromThread.get(), is("Thread2"));
-  }
+        assertThat(threadLocal.get(), is("Thread1"));
+        assertThat(fromThread.get(), is("Thread2"));
+    }
 
-  @Test
-  public void resetWorksForAllThreads() throws InterruptedException {
-    final ThreadLocal<String> threadLocal = new ThreadLocal<>("Initial");
-    final AtomicReference<String> fromThread = new AtomicReference<>();
+    @Test
+    public void resetWorksForAllThreads() throws InterruptedException {
+        final ThreadLocal<String> threadLocal = new ThreadLocal<>("Initial");
+        final AtomicReference<String> fromThread = new AtomicReference<>();
 
-    Thread thread =
-        new Thread(
-            () -> {
-              threadLocal.set("Thread2");
-              threadLocal.reset();
-              fromThread.set(threadLocal.get());
-            });
-    thread.start();
-    thread.join();
+        Thread thread =
+                new Thread(
+                        () -> {
+                            threadLocal.set("Thread2");
+                            threadLocal.reset();
+                            fromThread.set(threadLocal.get());
+                        });
+        thread.start();
+        thread.join();
 
-    assertThat(threadLocal.get(), is("Initial"));
-    assertThat(fromThread.get(), is("Initial"));
-  }
+        assertThat(threadLocal.get(), is("Initial"));
+        assertThat(fromThread.get(), is("Initial"));
+    }
 
-  @Test
-  public void initialValueWorksForAllThreads() throws InterruptedException {
-    final ThreadLocal<String> threadLocal = new ThreadLocal<>("Initial Value");
-    final AtomicReference<String> fromThread = new AtomicReference<>();
+    @Test
+    public void initialValueWorksForAllThreads() throws InterruptedException {
+        final ThreadLocal<String> threadLocal = new ThreadLocal<>("Initial Value");
+        final AtomicReference<String> fromThread = new AtomicReference<>();
 
-    Thread thread = new Thread(() -> fromThread.set(threadLocal.get()));
-    thread.start();
-    thread.join();
+        Thread thread = new Thread(() -> fromThread.set(threadLocal.get()));
+        thread.start();
+        thread.join();
 
-    assertThat(threadLocal.get(), is("Initial Value"));
-    assertThat(fromThread.get(), is("Initial Value"));
-  }
+        assertThat(threadLocal.get(), is("Initial Value"));
+        assertThat(fromThread.get(), is("Initial Value"));
+    }
 
-  @Test
-  public void initialValueSourceIsCalledSeparatelyPerThread() throws InterruptedException {
-    final ThreadLocal<String> threadLocal =
-        new ThreadLocal<>(() -> Thread.currentThread().getName());
-    final AtomicReference<String> fromThread = new AtomicReference<>();
+    @Test
+    public void initialValueSourceIsCalledSeparatelyPerThread() throws InterruptedException {
+        final ThreadLocal<String> threadLocal =
+                new ThreadLocal<>(() -> Thread.currentThread().getName());
+        final AtomicReference<String> fromThread = new AtomicReference<>();
 
-    Thread thread = new Thread(() -> fromThread.set(threadLocal.get()));
-    thread.start();
-    thread.join();
+        Thread thread = new Thread(() -> fromThread.set(threadLocal.get()));
+        thread.start();
+        thread.join();
 
-    assertThat(threadLocal.get(), is(Thread.currentThread().getName()));
-    assertThat(fromThread.get(), is(thread.getName()));
-  }
+        assertThat(threadLocal.get(), is(Thread.currentThread().getName()));
+        assertThat(fromThread.get(), is(thread.getName()));
+    }
 
-  @Test
-  public void initialValueSourceIsStateful() throws InterruptedException {
-    final ThreadLocal<AtomicReference<String>> threadLocal =
-        new ThreadLocal<>(() -> new AtomicReference<>("initial value"));
+    @Test
+    public void initialValueSourceIsStateful() throws InterruptedException {
+        final ThreadLocal<AtomicReference<String>> threadLocal =
+                new ThreadLocal<>(() -> new AtomicReference<>("initial value"));
 
-    threadLocal.get().set("new value");
+        threadLocal.get().set("new value");
 
-    assertThat(threadLocal.get().get(), is("new value"));
-  }
+        assertThat(threadLocal.get().get(), is("new value"));
+    }
 
-  @Test
-  public void initialValueSourceIsStatefulOtherThread() throws InterruptedException {
-    final ThreadLocal<AtomicReference<String>> threadLocal =
-        new ThreadLocal<>(() -> new AtomicReference<>("initial value"));
+    @Test
+    public void initialValueSourceIsStatefulOtherThread() throws InterruptedException {
+        final ThreadLocal<AtomicReference<String>> threadLocal =
+                new ThreadLocal<>(() -> new AtomicReference<>("initial value"));
 
-    final AtomicReference<String> fromThread = new AtomicReference<>();
+        final AtomicReference<String> fromThread = new AtomicReference<>();
 
-    Thread thread =
-        new Thread(
-            () -> {
-              threadLocal.get().set("new value");
-              fromThread.set(threadLocal.get().get());
-            });
-    thread.start();
-    thread.join();
+        Thread thread =
+                new Thread(
+                        () -> {
+                            threadLocal.get().set("new value");
+                            fromThread.set(threadLocal.get().get());
+                        });
+        thread.start();
+        thread.join();
 
-    assertThat(fromThread.get(), is("new value"));
-  }
+        assertThat(fromThread.get(), is("new value"));
+    }
 
-  @Test
-  public void removeWorks() {
-    ThreadLocal<String> threadLocal = new ThreadLocal<>("Initial Value");
-    threadLocal.set("New Value");
-    threadLocal.remove();
-    assertThat(threadLocal.get(), is("Initial Value"));
-  }
+    @Test
+    public void removeWorks() {
+        ThreadLocal<String> threadLocal = new ThreadLocal<>("Initial Value");
+        threadLocal.set("New Value");
+        threadLocal.remove();
+        assertThat(threadLocal.get(), is("Initial Value"));
+    }
 
-  @Test
-  public void removeWorksOtherThread() throws InterruptedException {
-    final ThreadLocal<String> threadLocal =
-        new ThreadLocal<>(() -> Thread.currentThread().getName());
-    final AtomicReference<String> fromThread = new AtomicReference<>();
+    @Test
+    public void removeWorksOtherThread() throws InterruptedException {
+        final ThreadLocal<String> threadLocal =
+                new ThreadLocal<>(() -> Thread.currentThread().getName());
+        final AtomicReference<String> fromThread = new AtomicReference<>();
 
-    Thread thread =
-        new Thread(
-            () -> {
-              threadLocal.set("New Value");
-              threadLocal.remove();
-              fromThread.set(threadLocal.get());
-            });
-    thread.start();
-    thread.join();
+        Thread thread =
+                new Thread(
+                        () -> {
+                            threadLocal.set("New Value");
+                            threadLocal.remove();
+                            fromThread.set(threadLocal.get());
+                        });
+        thread.start();
+        thread.join();
 
-    assertThat(threadLocal.get(), is(Thread.currentThread().getName()));
-    assertThat(fromThread.get(), is(thread.getName()));
-  }
+        assertThat(threadLocal.get(), is(Thread.currentThread().getName()));
+        assertThat(fromThread.get(), is(thread.getName()));
+    }
 }

--- a/src/test/java/uk/org/lidalia/lang/ThreadLocalTests.java
+++ b/src/test/java/uk/org/lidalia/lang/ThreadLocalTests.java
@@ -1,0 +1,136 @@
+package uk.org.lidalia.lang;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+
+/**
+ * This class was written by Robert Elliot and is originally located at
+ * https://github.com/Mahoney/lidalia-lang
+ */
+public class ThreadLocalTests {
+
+  @Test
+  public void differentValuePerThread() throws InterruptedException {
+    final ThreadLocal<String> threadLocal = new ThreadLocal<>("Initial");
+    final AtomicReference<String> fromThread = new AtomicReference<>();
+    threadLocal.set("Thread1");
+
+    Thread thread =
+        new Thread(
+            () -> {
+              threadLocal.set("Thread2");
+              fromThread.set(threadLocal.get());
+            });
+    thread.start();
+    thread.join();
+
+    assertThat(threadLocal.get(), is("Thread1"));
+    assertThat(fromThread.get(), is("Thread2"));
+  }
+
+  @Test
+  public void resetWorksForAllThreads() throws InterruptedException {
+    final ThreadLocal<String> threadLocal = new ThreadLocal<>("Initial");
+    final AtomicReference<String> fromThread = new AtomicReference<>();
+
+    Thread thread =
+        new Thread(
+            () -> {
+              threadLocal.set("Thread2");
+              threadLocal.reset();
+              fromThread.set(threadLocal.get());
+            });
+    thread.start();
+    thread.join();
+
+    assertThat(threadLocal.get(), is("Initial"));
+    assertThat(fromThread.get(), is("Initial"));
+  }
+
+  @Test
+  public void initialValueWorksForAllThreads() throws InterruptedException {
+    final ThreadLocal<String> threadLocal = new ThreadLocal<>("Initial Value");
+    final AtomicReference<String> fromThread = new AtomicReference<>();
+
+    Thread thread = new Thread(() -> fromThread.set(threadLocal.get()));
+    thread.start();
+    thread.join();
+
+    assertThat(threadLocal.get(), is("Initial Value"));
+    assertThat(fromThread.get(), is("Initial Value"));
+  }
+
+  @Test
+  public void initialValueSourceIsCalledSeparatelyPerThread() throws InterruptedException {
+    final ThreadLocal<String> threadLocal =
+        new ThreadLocal<>(() -> Thread.currentThread().getName());
+    final AtomicReference<String> fromThread = new AtomicReference<>();
+
+    Thread thread = new Thread(() -> fromThread.set(threadLocal.get()));
+    thread.start();
+    thread.join();
+
+    assertThat(threadLocal.get(), is(Thread.currentThread().getName()));
+    assertThat(fromThread.get(), is(thread.getName()));
+  }
+
+  @Test
+  public void initialValueSourceIsStateful() throws InterruptedException {
+    final ThreadLocal<AtomicReference<String>> threadLocal =
+        new ThreadLocal<>(() -> new AtomicReference<>("initial value"));
+
+    threadLocal.get().set("new value");
+
+    assertThat(threadLocal.get().get(), is("new value"));
+  }
+
+  @Test
+  public void initialValueSourceIsStatefulOtherThread() throws InterruptedException {
+    final ThreadLocal<AtomicReference<String>> threadLocal =
+        new ThreadLocal<>(() -> new AtomicReference<>("initial value"));
+
+    final AtomicReference<String> fromThread = new AtomicReference<>();
+
+    Thread thread =
+        new Thread(
+            () -> {
+              threadLocal.get().set("new value");
+              fromThread.set(threadLocal.get().get());
+            });
+    thread.start();
+    thread.join();
+
+    assertThat(fromThread.get(), is("new value"));
+  }
+
+  @Test
+  public void removeWorks() {
+    ThreadLocal<String> threadLocal = new ThreadLocal<>("Initial Value");
+    threadLocal.set("New Value");
+    threadLocal.remove();
+    assertThat(threadLocal.get(), is("Initial Value"));
+  }
+
+  @Test
+  public void removeWorksOtherThread() throws InterruptedException {
+    final ThreadLocal<String> threadLocal =
+        new ThreadLocal<>(() -> Thread.currentThread().getName());
+    final AtomicReference<String> fromThread = new AtomicReference<>();
+
+    Thread thread =
+        new Thread(
+            () -> {
+              threadLocal.set("New Value");
+              threadLocal.remove();
+              fromThread.set(threadLocal.get());
+            });
+    thread.start();
+    thread.join();
+
+    assertThat(threadLocal.get(), is(Thread.currentThread().getName()));
+    assertThat(fromThread.get(), is(thread.getName()));
+  }
+}


### PR DESCRIPTION
Going back to the custom ThreadLocal implementation (`uk.org.lidalia.lang.ThreadLocal`) in order to prevent memory leaks. 

The classes in which the custom ThreadLocal should be used are TestLogger and TestLoggerFactory which hold the loggingEvents attribute that contains LoggingEvent instances. On TestMDCAdapter it's not necessary since the ThreadLocal attribute (`value`) contains a Map of String keys and values, not LoggingEvents.

As requested by @valfirst, in order not to add an extra dependency, I'm copying the original implementation from https://github.com/Mahoney/lidalia-lang giving credit to the author in the comments.

Closes #255 