### PR TITLE
GH-314: New setting to configure global capture level

### DIFF
--- a/src/main/java/com/github/valfirst/slf4jtest/TestLogger.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLogger.java
@@ -457,7 +457,7 @@ public class TestLogger implements Logger {
             final Optional<Throwable> throwable,
             final String format,
             final Object... args) {
-        if (enabledLevels.get().contains(level)) {
+        if (enabledLevels.get().contains(level) && enabledByGlobalCaptureLevel(level)) {
             final LoggingEvent event =
                     new LoggingEvent(of(this), level, mdc(), marker, throwable, format, args);
             allLoggingEvents.add(event);
@@ -465,6 +465,10 @@ public class TestLogger implements Logger {
             testLoggerFactory.addLoggingEvent(event);
             optionallyPrint(event);
         }
+    }
+
+    private boolean enabledByGlobalCaptureLevel(Level level) {
+        return testLoggerFactory.getCaptureLevel().compareTo(level) <= 0;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/site/markdown/changelog.md
+++ b/src/site/markdown/changelog.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### Unreleased
+
+Introduce a new `capture.level` property and API to control captured events globally,
+see https://github.com/valfirst/slf4j-test/issues/314.
+
 ### Version 1.2.0
 
 Allows construction of standalone instances to facilitate logging in different

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -19,7 +19,7 @@ LoggingEvent.
 ### Setting the Log Level on a Logger
 
 SLF4J Test only stores events for levels which are marked as enabled on the
-Logger. By default all levels are enabled; however, this can be programatically
+Logger. By default, all levels are enabled; however, this can be programmatically
 changed on a per logger basis using the following functions:
 
     Logger.setEnabledLevels(Level... levels)
@@ -32,6 +32,28 @@ is concerned, notwithstanding the fact that implementations such as Logback and
 Log4J do not permit this. If you wish to test using these common configurations,
 you should use the constants defined in
 uk.org.lidalia.slf4jext.ConventionalLevelHierarchy.
+
+### Globally disabling a Log Level
+
+Storing log events at all levels can slow down test executions. If needed a global
+setting can be used to avoid capturing events at a given level or below respecting
+the conventional level hierarchy (if the capture level is set to INFO, DEBUG and TRACE
+events won't be captured). This can be set in any of the following ways:
+
+#### Programmatically
+    TestLoggerFactory.getInstance().setCaptureLevel(Level.INFO);
+
+#### Via a System Property
+Run the JVM with the following:
+
+    -Dslf4jtest.capture.level=INFO
+
+#### Via a properties file
+Place a file called slf4jtest.properties on the classpath with the following
+line in it:
+
+    capture.level=INFO
+
 
 ### Resetting Stored State
 
@@ -93,10 +115,12 @@ It can still be useful to print log messages to System out/err as appropriate.
 SLF4J Test will print messages using a standard (non-configurable) format based
 on the value of the TestLoggerFactory's printLevel property. For convenience
 this does respect the conventional level hierarchy where if the print level is
-INFO logging events at levels WARN and ERROR will also be printed. This can be
-set in any of the following ways:
+INFO logging events at levels WARN and ERROR will also be printed. A level that is
+disabled [globally](#globally-disabling-a-log-level) will not be printed.
 
-#### Programatically
+This can be set in any of the following ways:
+
+#### Programmatically
     TestLoggerFactory.getInstance().setPrintLevel(Level.INFO);
 
 #### Via a System Property

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryTests.java
@@ -248,6 +248,7 @@ public class TestLoggerFactoryTests {
         final OverridableProperties properties = mock(OverridableProperties.class);
         whenNew(OverridableProperties.class).withArguments("slf4jtest").thenReturn(properties);
         when(properties.getProperty("print.level", "OFF")).thenReturn("INFO");
+        when(properties.getProperty("capture.level", "TRACE")).thenReturn("INFO");
 
         assertThat(getInstance().getPrintLevel(), is(Level.INFO));
     }
@@ -267,6 +268,44 @@ public class TestLoggerFactoryTests {
                 is(
                         "Invalid level name in property print.level of file slf4jtest.properties "
                                 + "or System property slf4jtest.print.level"));
+        assertThat(illegalStateException.getCause(), instanceOf(IllegalArgumentException.class));
+        assertThat(
+                illegalStateException.getCause().getMessage(),
+                is("No enum constant " + Level.class.getName() + "." + invalidLevelName));
+    }
+
+    @Test
+    public void defaultCaptureLevelIsTrace() {
+        assertThat(getInstance().getCaptureLevel(), is(Level.TRACE));
+    }
+
+    @Test
+    @PrepareForTest(TestLoggerFactory.class)
+    public void captureLevelTakenFromOverridableProperties() throws Exception {
+        final OverridableProperties properties = mock(OverridableProperties.class);
+        whenNew(OverridableProperties.class).withArguments("slf4jtest").thenReturn(properties);
+        when(properties.getProperty("print.level", "OFF")).thenReturn("INFO");
+        when(properties.getProperty("capture.level", "TRACE")).thenReturn("INFO");
+
+        assertThat(getInstance().getCaptureLevel(), is(Level.INFO));
+    }
+
+    @Test
+    @PrepareForTest(TestLoggerFactory.class)
+    public void captureLevelInvalidInOverridableProperties() throws Exception {
+        final OverridableProperties properties = mock(OverridableProperties.class);
+        whenNew(OverridableProperties.class).withArguments("slf4jtest").thenReturn(properties);
+        when(properties.getProperty("print.level", "OFF")).thenReturn("INFO");
+        final String invalidLevelName = "nonsense";
+        when(properties.getProperty("capture.level", "TRACE")).thenReturn(invalidLevelName);
+
+        final IllegalStateException illegalStateException =
+                assertThrows(IllegalStateException.class, TestLoggerFactory::getInstance);
+        assertThat(
+                illegalStateException.getMessage(),
+                is(
+                        "Invalid level name in property capture.level of file slf4jtest.properties "
+                                + "or System property slf4jtest.capture.level"));
         assertThat(illegalStateException.getCause(), instanceOf(IllegalArgumentException.class));
         assertThat(
                 illegalStateException.getCause().getMessage(),


### PR DESCRIPTION
Introduce a new global setting `capture.level` to disable storing (and printing) logs at a given level (following the level hierarchy).

The implementation is very similar to the `print.level` global setting.

This is useful when tests are generating a lot of logging events that are not of interest and don't need to be captured. ArchUnit tests are known to be such tests and can be quite slow when slf4j-test is used.