### PR TITLE
Switch from Lidalia Level to SLF4J Level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,11 +90,6 @@
             <version>31.1-jre</version>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
-            <artifactId>lidalia-slf4j-ext</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>2.12.5</version>

--- a/src/main/java/com/github/valfirst/slf4jtest/AbstractTestLoggerAssert.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/AbstractTestLoggerAssert.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.assertj.core.api.AbstractAssert;
-import uk.org.lidalia.slf4jext.Level;
+import org.slf4j.event.Level;
 
 abstract class AbstractTestLoggerAssert<C extends AbstractAssert<C, TestLogger>>
         extends AbstractAssert<C, TestLogger> {

--- a/src/main/java/com/github/valfirst/slf4jtest/LevelAssert.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/LevelAssert.java
@@ -3,7 +3,7 @@ package com.github.valfirst.slf4jtest;
 import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import uk.org.lidalia.slf4jext.Level;
+import org.slf4j.event.Level;
 
 /**
  * A set of assertions to validate that logs have been logged to a {@link TestLogger}, for a

--- a/src/main/java/com/github/valfirst/slf4jtest/LoggingEvent.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/LoggingEvent.java
@@ -15,8 +15,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.joda.time.Instant;
 import org.slf4j.Marker;
+import org.slf4j.event.Level;
 import org.slf4j.helpers.MessageFormatter;
-import uk.org.lidalia.slf4jext.Level;
 
 /**
  * Representation of a call to a logger for test assertion purposes. The contract of {@link

--- a/src/main/java/com/github/valfirst/slf4jtest/TestLoggerAssert.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLoggerAssert.java
@@ -5,7 +5,7 @@ import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import org.slf4j.Marker;
-import uk.org.lidalia.slf4jext.Level;
+import org.slf4j.event.Level;
 
 /**
  * A set of assertions to validate that logs have been logged to a {@link TestLogger}.

--- a/src/main/java/com/github/valfirst/slf4jtest/TestLoggerFactory.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLoggerFactory.java
@@ -1,7 +1,5 @@
 package com.github.valfirst.slf4jtest;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -16,8 +14,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 import org.slf4j.ILoggerFactory;
+import org.slf4j.event.Level;
 import uk.org.lidalia.lang.ThreadLocal;
-import uk.org.lidalia.slf4jext.Level;
 
 public final class TestLoggerFactory implements ILoggerFactory {
 
@@ -39,6 +37,7 @@ public final class TestLoggerFactory implements ILoggerFactory {
             throws IOException {
         try {
             final String printLevelProperty = properties.getProperty(propertyKey, defaultValue);
+            if ("OFF".equals(printLevelProperty)) return null;
             return Level.valueOf(printLevelProperty);
         } catch (IllegalArgumentException e) {
             throw new IllegalStateException(
@@ -95,7 +94,7 @@ public final class TestLoggerFactory implements ILoggerFactory {
     }
 
     public TestLoggerFactory() {
-        this(Level.OFF, Level.TRACE);
+        this(null, Level.TRACE);
     }
 
     public TestLoggerFactory(final Level printLevel) {
@@ -103,8 +102,8 @@ public final class TestLoggerFactory implements ILoggerFactory {
     }
 
     public TestLoggerFactory(final Level printLevel, final Level captureLevel) {
-        this.printLevel = checkNotNull(printLevel);
-        this.captureLevel = checkNotNull(captureLevel);
+        this.printLevel = printLevel;
+        this.captureLevel = captureLevel;
     }
 
     public Level getPrintLevel() {
@@ -162,10 +161,10 @@ public final class TestLoggerFactory implements ILoggerFactory {
     }
 
     public void setPrintLevel(final Level printLevel) {
-        this.printLevel = checkNotNull(printLevel);
+        this.printLevel = printLevel;
     }
 
     public void setCaptureLevel(Level captureLevel) {
-        this.captureLevel = checkNotNull(captureLevel);
+        this.captureLevel = captureLevel;
     }
 }

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -13,7 +13,7 @@ LoggingEvent to facilitate easy construction of expected events for comparison
 against those that were actually received, and LoggingEvent has appropriate
 equals, hashCode and toString implementations for this purpose. See the [front
 ](./index.html) page for an example of using the [info static factory method
-](./xref/com/github/valfirst/slf4jtest/TestLogger.html#L241)to create an expected
+](./xref/com/github/valfirst/slf4jtest/LoggingEvent.html#L161) to create an expected
 LoggingEvent.
 
 #### Custom Predicates
@@ -47,9 +47,7 @@ It's important to note that SLF4J does *not* imply any relationship between the
 levels - it is perfectly possible for a logger to be enabled for INFO but
 disabled for ERROR as far as SLF4J is concerned, and hence as far as SLF4J Test
 is concerned, notwithstanding the fact that implementations such as Logback and
-Log4J do not permit this. If you wish to test using these common configurations,
-you should use the constants defined in
-uk.org.lidalia.slf4jext.ConventionalLevelHierarchy.
+Log4J do not permit this.
 
 ### Globally disabling a Log Level
 

--- a/src/test/java/com/github/valfirst/slf4jtest/LevelAssertTest.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/LevelAssertTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.org.lidalia.slf4jext.Level;
+import org.slf4j.event.Level;
 
 @ExtendWith(MockitoExtension.class)
 class LevelAssertTest {

--- a/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
@@ -20,11 +20,11 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
-import static uk.org.lidalia.slf4jext.Level.DEBUG;
-import static uk.org.lidalia.slf4jext.Level.ERROR;
-import static uk.org.lidalia.slf4jext.Level.INFO;
-import static uk.org.lidalia.slf4jext.Level.TRACE;
-import static uk.org.lidalia.slf4jext.Level.WARN;
+import static org.slf4j.event.Level.DEBUG;
+import static org.slf4j.event.Level.ERROR;
+import static org.slf4j.event.Level.INFO;
+import static org.slf4j.event.Level.TRACE;
+import static org.slf4j.event.Level.WARN;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -48,7 +48,7 @@ import org.junitpioneer.jupiter.StdErr;
 import org.junitpioneer.jupiter.StdIo;
 import org.junitpioneer.jupiter.StdOut;
 import org.slf4j.Marker;
-import uk.org.lidalia.slf4jext.Level;
+import org.slf4j.event.Level;
 
 class LoggingEventTests {
 

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.OngoingStubbing;
-import uk.org.lidalia.slf4jext.Level;
+import org.slf4j.event.Level;
 
 @ExtendWith(MockitoExtension.class)
 class TestLoggerAssertionsTest {

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryExtensionTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryExtensionTests.java
@@ -8,7 +8,7 @@ import static org.hamcrest.core.Is.is;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import uk.org.lidalia.slf4jext.LoggerFactory;
+import org.slf4j.LoggerFactory;
 
 @ExtendWith(TestLoggerFactoryExtension.class)
 class TestLoggerFactoryExtensionTests {

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryExtensionUnitTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryExtensionUnitTests.java
@@ -4,15 +4,16 @@ import static com.github.valfirst.slf4jtest.LoggingEvent.info;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static uk.org.lidalia.slf4jext.Level.DEBUG;
-import static uk.org.lidalia.slf4jext.Level.INFO;
+import static org.slf4j.event.Level.DEBUG;
+import static org.slf4j.event.Level.INFO;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.org.lidalia.slf4jext.Level;
+import org.slf4j.event.Level;
 
 class TestLoggerFactoryExtensionUnitTests {
 
@@ -29,7 +30,7 @@ class TestLoggerFactoryExtensionUnitTests {
 
         assertThat(TestLoggerFactory.getLoggingEvents(), is(Collections.emptyList()));
         assertThat(logger.getLoggingEvents(), is(Collections.emptyList()));
-        assertThat(logger.getEnabledLevels(), is(Level.enablableValueSet()));
+        assertThat(logger.getEnabledLevels(), is(EnumSet.allOf(Level.class)));
     }
 
     @Test

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryResetRuleTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryResetRuleTests.java
@@ -9,7 +9,7 @@ import static org.hamcrest.core.Is.is;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
-import uk.org.lidalia.slf4jext.LoggerFactory;
+import org.slf4j.LoggerFactory;
 
 public class TestLoggerFactoryResetRuleTests {
 

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryResetRuleUnitTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryResetRuleUnitTests.java
@@ -5,17 +5,18 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static uk.org.lidalia.slf4jext.Level.DEBUG;
-import static uk.org.lidalia.slf4jext.Level.INFO;
+import static org.slf4j.event.Level.DEBUG;
+import static org.slf4j.event.Level.INFO;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import uk.org.lidalia.slf4jext.Level;
+import org.slf4j.event.Level;
 
 class TestLoggerFactoryResetRuleUnitTests {
 
@@ -37,7 +38,7 @@ class TestLoggerFactoryResetRuleUnitTests {
                                         TestLoggerFactory.getLoggingEvents(),
                                         is(Collections.<LoggingEvent>emptyList()));
                                 assertThat(logger.getLoggingEvents(), is(Collections.<LoggingEvent>emptyList()));
-                                assertThat(logger.getEnabledLevels(), is(Level.enablableValueSet()));
+                                assertThat(logger.getEnabledLevels(), is(EnumSet.allOf(Level.class)));
                             }
                         },
                         Description.EMPTY)
@@ -62,7 +63,7 @@ class TestLoggerFactoryResetRuleUnitTests {
 
         assertThat(TestLoggerFactory.getLoggingEvents(), is(Collections.<LoggingEvent>emptyList()));
         assertThat(logger.getLoggingEvents(), is(Collections.<LoggingEvent>emptyList()));
-        assertThat(logger.getEnabledLevels(), is(Level.enablableValueSet()));
+        assertThat(logger.getEnabledLevels(), is(EnumSet.allOf(Level.class)));
     }
 
     @Test
@@ -91,7 +92,7 @@ class TestLoggerFactoryResetRuleUnitTests {
         assertThat(thrown, is(toThrow));
         assertThat(TestLoggerFactory.getLoggingEvents(), is(Collections.<LoggingEvent>emptyList()));
         assertThat(logger.getLoggingEvents(), is(Collections.<LoggingEvent>emptyList()));
-        assertThat(logger.getEnabledLevels(), is(Level.enablableValueSet()));
+        assertThat(logger.getEnabledLevels(), is(EnumSet.allOf(Level.class)));
     }
 
     @Test

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryTests.java
@@ -9,6 +9,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -16,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
-import static uk.org.lidalia.slf4jext.Level.WARN;
+import static org.slf4j.event.Level.WARN;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -29,7 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import uk.org.lidalia.slf4jext.Level;
+import org.slf4j.event.Level;
 
 @RunWith(PowerMockRunner.class)
 public class TestLoggerFactoryTests {
@@ -239,7 +240,7 @@ public class TestLoggerFactoryTests {
 
     @Test
     public void defaultPrintLevelIsOff() {
-        assertThat(getInstance().getPrintLevel(), is(Level.OFF));
+        assertThat(getInstance().getPrintLevel(), is(nullValue()));
     }
 
     @Test
@@ -335,7 +336,7 @@ public class TestLoggerFactoryTests {
     public void resetLoggerFactory() {
         try {
             TestLoggerFactory.reset();
-            getInstance().setPrintLevel(Level.OFF);
+            getInstance().setPrintLevel(null);
         } catch (IllegalStateException | UncheckedIOException e) {
             // ignore
         }


### PR DESCRIPTION
This is the first part of #380, changing the `Level` class from `uk.org.lidalia.slf4jext.Level` to `org.slf4j.event.Level`.