### PR TITLE
392 inheritance of mdcs

### DIFF
--- a/src/main/java/com/github/valfirst/slf4jtest/LoggingEvent.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/LoggingEvent.java
@@ -407,7 +407,8 @@ public class LoggingEvent {
         super();
         this.creatingLogger = creatingLogger;
         this.level = requireNonNull(level);
-        this.mdc = Collections.unmodifiableMap(new TreeMap<>(mdc));
+        this.mdc =
+                mdc == null ? Collections.emptyMap() : Collections.unmodifiableMap(new TreeMap<>(mdc));
         this.marker = requireNonNull(marker);
         this.throwable = requireNonNull(throwable);
         this.message = message;

--- a/src/main/java/com/github/valfirst/slf4jtest/OverridableProperties.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/OverridableProperties.java
@@ -2,6 +2,7 @@ package com.github.valfirst.slf4jtest;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.Properties;
 
 class OverridableProperties {
@@ -36,5 +37,13 @@ class OverridableProperties {
     String getProperty(final String propertyKey, final String defaultValue) {
         final String propertyFileProperty = properties.getProperty(propertyKey, defaultValue);
         return System.getProperty(propertySourceName + "." + propertyKey, propertyFileProperty);
+    }
+
+    public static OverridableProperties createUnchecked(final String propertySourceName) {
+        try {
+            return new OverridableProperties(propertySourceName);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/src/main/java/com/github/valfirst/slf4jtest/TestLoggerFactory.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLoggerFactory.java
@@ -1,7 +1,5 @@
 package com.github.valfirst.slf4jtest;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,18 +43,17 @@ public final class TestLoggerFactory implements ILoggerFactory {
         if (INSTANCE == null) {
             synchronized (TestLoggerFactory.class) {
                 if (INSTANCE == null) {
-                    try {
-                        OverridableProperties properties = new OverridableProperties("slf4jtest");
-                        Level printLevel = getLevelProperty(properties, "print.level", "OFF");
-                        Level captureLevel = getLevelProperty(properties, "capture.level", "TRACE");
-                        INSTANCE = new TestLoggerFactory(printLevel, captureLevel);
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
+                    INSTANCE = createInstance(OverridableProperties.createUnchecked("slf4jtest"));
                 }
             }
         }
         return INSTANCE;
+    }
+
+    static TestLoggerFactory createInstance(OverridableProperties properties) {
+        Level printLevel = getLevelProperty(properties, "print.level", "OFF");
+        Level captureLevel = getLevelProperty(properties, "capture.level", "TRACE");
+        return new TestLoggerFactory(printLevel, captureLevel);
     }
 
     public static TestLogger getTestLogger(final Class<?> aClass) {

--- a/src/main/java/com/github/valfirst/slf4jtest/TestMDCAdapter.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestMDCAdapter.java
@@ -3,40 +3,228 @@ package com.github.valfirst.slf4jtest;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.slf4j.MDC;
 import org.slf4j.helpers.BasicMDCAdapter;
 
 public class TestMDCAdapter extends BasicMDCAdapter {
 
-    private final ThreadLocal<Map<String, String>> value = ThreadLocal.withInitial(HashMap::new);
+    private final ThreadLocal<Map<String, String>> value;
+    private final boolean initialEnable;
+    private final boolean initialInherit;
+    private final boolean initialReturnNullCopyWhenMdcNotSet;
+    private final boolean initialAllowNullValues;
+    private volatile boolean enable;
+    private volatile boolean inherit;
+    private volatile boolean returnNullCopyWhenMdcNotSet;
+    private volatile boolean allowNullValues;
+
+    public TestMDCAdapter() {
+        this(OverridableProperties.createUnchecked("slf4jtest"));
+    }
+
+    TestMDCAdapter(OverridableProperties properties) {
+        enable = initialEnable = getBooleanProperty(properties, "mdc.enable", true);
+        inherit = initialInherit = getBooleanProperty(properties, "mdc.inherit", false);
+        returnNullCopyWhenMdcNotSet =
+                initialReturnNullCopyWhenMdcNotSet =
+                        getBooleanProperty(properties, "mdc.return.null.copy.when.mdc.not.set", false);
+        allowNullValues =
+                initialAllowNullValues = getBooleanProperty(properties, "mdc.allow.null.values", true);
+
+        value =
+                new InheritableThreadLocal<Map<String, String>>() {
+                    @Override
+                    protected Map<String, String> childValue(Map<String, String> parentValue) {
+                        if (enable && inherit && parentValue != null) {
+                            return new HashMap<>(parentValue);
+                        } else {
+                            return null;
+                        }
+                    }
+                };
+    }
+
+    static boolean getBooleanProperty(
+            OverridableProperties properties, String propertyKey, boolean defaultValue) {
+        return Boolean.valueOf(properties.getProperty(propertyKey, String.valueOf(defaultValue)));
+    }
 
     @Override
     public void put(final String key, final String val) {
-        value.get().put(key, val);
+        if (!enable) return;
+        if (key == null) throw new IllegalArgumentException("key cannot be null");
+        if (val == null && !allowNullValues) throw new IllegalArgumentException("val cannot be null");
+        Map<String, String> map = value.get();
+        if (map == null) {
+            map = new HashMap<>();
+            value.set(map);
+        }
+        map.put(key, val);
     }
 
     @Override
     public String get(final String key) {
-        return value.get().get(key);
+        if (!enable) return null;
+        if (key == null) throw new IllegalArgumentException("key cannot be null");
+        Map<String, String> map = value.get();
+        if (map != null) {
+            return map.get(key);
+        } else {
+            return null;
+        }
     }
 
     @Override
     public void remove(final String key) {
-        value.get().remove(key);
+        if (!enable) return;
+        if (key == null) throw new IllegalArgumentException("key cannot be null");
+        Map<String, String> map = value.get();
+        if (map != null) map.remove(key);
     }
 
     @Override
     public void clear() {
-        value.get().clear();
+        if (!enable) return;
+        Map<String, String> map = value.get();
+        if (map == null) return;
+        map.clear();
         value.remove();
     }
 
+    /**
+     * Return a copy of the current thread's context map. It is a {@link SortedMap}, using the natural
+     * order of the keys. This makes it easier to spot discrepancies if an assertion fails. The
+     * returned map is unmodifiable. {@code null} is returned if
+     *
+     * <ul>
+     *   <li>The MDC functionality is disabled, c.f. <code>setEnable</code>, or
+     *   <li>"return null when empty" is enabled, c.f. <code>setReturnNullCopyWhenMdcNotSet</code>,
+     *       and <code>put</code> has not been called.
+     * </ul>
+     *
+     * @return A copy of the current thread's context map.
+     */
     @Override
     public Map<String, String> getCopyOfContextMap() {
-        return Collections.unmodifiableMap(new HashMap<>(value.get()));
+        if (!enable) return null;
+        Map<String, String> map = value.get();
+        if (map == null) {
+            if (returnNullCopyWhenMdcNotSet) {
+                return null;
+            } else {
+                return Collections.emptyMap();
+            }
+        } else {
+            return Collections.unmodifiableMap(new TreeMap<>(map));
+        }
     }
 
     @Override
     public void setContextMap(final Map<String, String> contextMap) {
+        if (!enable) return;
+        if (contextMap == null) {
+            clear();
+            return;
+        }
+        if (contextMap.keySet().contains(null))
+            throw new IllegalArgumentException("key cannot be null");
+        if (!allowNullValues && contextMap.values().contains(null))
+            throw new IllegalArgumentException("val cannot be null");
         value.set(new HashMap<>(contextMap));
+    }
+
+    /**
+     * Enable the MDC functionality for all threads.
+     *
+     * @param enable Whether to enable the MDC functionality. The default value is {@code true}.
+     */
+    public void setEnable(boolean enable) {
+        this.enable = enable;
+    }
+
+    /**
+     * Define whether child threads inherit a copy of the MDC from its parent thread. Note that the
+     * copy is taken when the {@link Thread} is constructed. This affects all threads.
+     *
+     * @param inherit Whether to enable inheritance. The default value is {@code false}.
+     */
+    public void setInherit(boolean inherit) {
+        this.inherit = inherit;
+    }
+
+    /**
+     * Define whether null values are allowed in the MDC. This affects all threads.
+     *
+     * @param allowNullValues Whether to allow nulls. The default value is {@code true}.
+     */
+    public void setAllowNullValues(boolean allowNullValues) {
+        this.allowNullValues = allowNullValues;
+    }
+
+    /**
+     * Define whether {@link #getCopyOfContextMap} returns {@code null} when no values have been set.
+     * This affects all threads.
+     *
+     * @param returnNullCopyWhenMdcNotSet Whether to return null. The default value is {@code false}.
+     *     If {@code false}, an empty map is returned instead.
+     */
+    public void setReturnNullCopyWhenMdcNotSet(boolean returnNullCopyWhenMdcNotSet) {
+        this.returnNullCopyWhenMdcNotSet = returnNullCopyWhenMdcNotSet;
+    }
+
+    /**
+     * Whether the MDC functionality is enabled.
+     *
+     * @return Whether the MDC functionality is enabled.
+     */
+    public boolean getEnable() {
+        return enable;
+    }
+
+    /**
+     * Whether child threads inherit a copy of the MDC from its parent thread.
+     *
+     * @return Whether inheritance is enabled.
+     */
+    public boolean getInherit() {
+        return inherit;
+    }
+
+    /**
+     * Whether null values are allowed in the MDC.
+     *
+     * @return Whether nulls are allowed.
+     */
+    public boolean getAllowNullValues() {
+        return allowNullValues;
+    }
+
+    /**
+     * Whether {@link #getCopyOfContextMap} returns {@code null} when no values have been set.
+     *
+     * @return Whether to return null.
+     */
+    public boolean getReturnNullCopyWhenMdcNotSet() {
+        return returnNullCopyWhenMdcNotSet;
+    }
+
+    /**
+     * Reset the options to values defined by the static configuration. This undoes to changes made
+     * using {@link #setEnable}, {@link #setInherit}, {@link #setAllowNullValues}, and {@link
+     * #setReturnNullCopyWhenMdcNotSet}.
+     */
+    public void restoreOptions() {
+        enable = initialEnable;
+        inherit = initialInherit;
+        returnNullCopyWhenMdcNotSet = initialReturnNullCopyWhenMdcNotSet;
+        allowNullValues = initialAllowNullValues;
+    }
+
+    /** Access the current MDC adapter. Used to call the option setting methods. */
+    @SuppressWarnings("unchecked")
+    public static TestMDCAdapter getInstance() {
+        return (TestMDCAdapter) MDC.getMDCAdapter();
     }
 }

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -188,3 +188,121 @@ doing this declaratively. For example
         }
         ...
     }
+
+### Customizing the MDC
+The MDC (original meaning Mapped Diagnostic Context) is a place that can
+be used to store additional information as key/value pairs. The
+information is stored by thread. It can be set by the client code and used
+by the logging backend.
+The [specification](https://www.slf4j.org/apidocs/org/slf4j/MDC.html) of 
+the MDC in SLF4J leaves much detail up to the logging backend. 
+
+SLF4J Test lets the user customize the behavior of the MDC to more closely
+match that of the backend expected to be used at run-time.
+
+The configuration can be changed in the property file `slf4jtest.properties`,
+using system properties specified as command line arguments to the JVM,
+or programatically. The property file and the system properties are read
+at start-up time, with system properties overriding the property file.
+Note that changing the values programatically affects all threads.
+
+#### Completely Disable the MDC
+The backend does not even have to implement the MDC at all.
+If the log4j2 adapter or logback is used, there is full support for the MDC.
+Using the java.util.logging adapter, there is an MDC, but it cannot be used
+by log appenders.
+In the slf4j-simple, the MDC implentation is a no-op.
+
+It is possible to disable the MDC completely by specifying
+
+##### Programmatically
+
+    TestMDCAdapter.getInstance().setEnable(false);
+
+##### Via a System Property
+
+    -Dslf4jtest.mdc.enable=false
+
+##### In the slf4j.properties File
+
+    mdc.enable=false
+
+The default value is `true`. If disabled, the `get` and `getCopyOfContextMap`
+methods return null, and all other methods are no-ops.
+
+#### Inheritance from the Parent Thread
+It is unspecified whether a child thread inherits the MDC from its parent.
+In log4j2 and logback, the MDC is not inherited by default, but this
+behavoir can be changed by the configuration. Using the java.util.logging
+adapter, inheritance is always on.
+
+##### Programmatically
+
+    TestMDCAdapter.getInstance().setInherit(true);
+
+##### Via a System Property
+
+    -Dslf4jtest.mdc.inherit=true
+
+##### In the slf4j.properties File
+
+    mdc.inherit=true
+
+The default value is `false`.
+
+#### Allow null values
+In the description of the
+[`put`](https://www.slf4j.org/apidocs/org/slf4j/MDC.html#put-java.lang.String-java.lang.String-)
+method, it says "The `val` parameter can be null only if the underlying
+implementation supports it."
+To emulate a backend that does not support null values, this can be configured.
+
+##### Programmatically
+
+    TestMDCAdapter.getInstance().setAllowNullValues(false);
+
+##### Via a System Property
+
+    -Dslf4jtest.mdc.allow.null.values=false
+
+##### In the slf4j.properties File
+
+    mdc.allow.null.values=false
+
+The default value is `true`.
+Note that if the MDC functionality has been completely disabled, null
+values are accepted and ignored, regardless of this setting.
+
+#### Null Returned for Empty Map
+The description of the
+[`getCopyOfContextMap`](https://www.slf4j.org/apidocs/org/slf4j/MDC.html#getCopyOfContextMap--)
+method says "Returned value may be null.", but it is not specified under
+which circumstances it may be null. Obviously, a backend that does not
+support an MDC will return null. The implementation in the
+java.util.logging adapter returns null, if `put` has not been called.
+Other implementations may return an empty map in that case.
+To change the behavior:
+
+##### Programmatically
+
+    TestMDCAdapter.getInstance().setReturnNullCopyWhenMdcNotSet(true);
+
+##### Via a System Property
+
+    -Dslf4jtest.mdc.return.null.copy.when.mdc.not.set=true
+
+##### In the slf4j.properties File
+
+    mdc.return.null.copy.when.mdc.not.set=true
+
+The default value is `false`, in which case an empty map is returned
+when the MDC is not set.
+Note that if the MDC functionality has been completely disabled,
+`null` is returned, regardless of this setting.
+
+#### Restoring Options
+To restore these options to the values defined by the initial
+configuration, use
+
+    TestMDCAdapter.getInstance().restoreOptions();
+

--- a/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
@@ -16,6 +16,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
@@ -539,6 +540,12 @@ class LoggingEventTests {
     void nullArgumentIsFormattedLikeSlf4j() {
         LoggingEvent event = new LoggingEvent(level, "message with {}, {}", null, "value");
         assertThat(event.getFormattedMessage(), is("message with null, value"));
+    }
+
+    @Test
+    void nullMdcGivesEmptyMdc() {
+        LoggingEvent event = new LoggingEvent(level, (Map<String, String>) null, message);
+        assertEquals(Collections.emptyMap(), event.getMdc());
     }
 
     public interface TriFunction<A, B, C, R> {

--- a/src/test/java/com/github/valfirst/slf4jtest/OverridablePropertiesTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/OverridablePropertiesTests.java
@@ -1,38 +1,48 @@
 package com.github.valfirst.slf4jtest;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 import java.io.IOException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
+import java.io.UncheckedIOException;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-class OverridablePropertiesTests {
+@RunWith(PowerMockRunner.class)
+public class OverridablePropertiesTests {
 
     private static final String PROPERTY_SOURCE_NAME = "test";
     private static final String PROPERTY_IN_BOTH = "bothprop";
     private static final String PROPERTY_IN_SYSTEM_PROPS = "sysprop";
 
-    @AfterEach
+    @After
     public void resetLoggerFactory() {
         System.getProperties().remove(PROPERTY_SOURCE_NAME + "." + PROPERTY_IN_BOTH);
         System.getProperties().remove(PROPERTY_SOURCE_NAME + "." + PROPERTY_IN_SYSTEM_PROPS);
     }
 
     @Test
-    void propertyNotInEither() throws IOException {
+    public void propertyNotInEither() throws IOException {
         final String defaultValue = "sensible_default";
         OverridableProperties properties = new OverridableProperties(PROPERTY_SOURCE_NAME);
         assertEquals(defaultValue, properties.getProperty("notpresent", defaultValue));
     }
 
     @Test
-    void propertyInFileNotInSystemProperties() throws IOException {
+    public void propertyInFileNotInSystemProperties() throws IOException {
         OverridableProperties properties = new OverridableProperties(PROPERTY_SOURCE_NAME);
         assertEquals("file value", properties.getProperty("infile", "default"));
     }
 
     @Test
-    void propertyNotInFileInSystemProperties() throws IOException {
+    public void propertyNotInFileInSystemProperties() throws IOException {
         final String expectedValue = "system value";
         System.setProperty(PROPERTY_SOURCE_NAME + "." + PROPERTY_IN_SYSTEM_PROPS, expectedValue);
 
@@ -41,7 +51,7 @@ class OverridablePropertiesTests {
     }
 
     @Test
-    void propertyInBothFileAndSystemProperties() throws IOException {
+    public void propertyInBothFileAndSystemProperties() throws IOException {
         final String expectedValue = "system value";
         System.setProperty(PROPERTY_SOURCE_NAME + "." + PROPERTY_IN_BOTH, expectedValue);
 
@@ -50,10 +60,24 @@ class OverridablePropertiesTests {
     }
 
     @Test
-    void noPropertyFile() throws IOException {
+    public void noPropertyFile() throws IOException {
         OverridableProperties properties = new OverridableProperties("no-property-file");
 
         final String defaultValue = "sensible_default";
         assertEquals(defaultValue, properties.getProperty("blah", defaultValue));
+    }
+
+    @Test
+    @PrepareForTest(OverridableProperties.class)
+    public void ioExceptionAtPropertiesLoading() throws Exception {
+        IOException ioException = new IOException();
+        whenNew(OverridableProperties.class).withArguments(anyString()).thenThrow(ioException);
+
+        try {
+            OverridableProperties.createUnchecked("somesource");
+            fail("UncheckedIOException was not thrown");
+        } catch (UncheckedIOException uncheckedIOException) {
+            assertThat(uncheckedIOException.getCause(), is(ioException));
+        }
     }
 }

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerFactoryTests.java
@@ -11,32 +11,28 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.slf4j.event.Level.WARN;
 
-import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
-@RunWith(PowerMockRunner.class)
-public class TestLoggerFactoryTests {
+class TestLoggerFactoryTests {
 
     @Test
-    public void getLoggerDifferentNames() {
+    void getLoggerDifferentNames() {
         TestLogger logger1 = getInstance().getLogger("name1");
         TestLogger logger2 = getInstance().getLogger("name2");
 
@@ -44,7 +40,7 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void getLoggerSameNames() {
+    void getLoggerSameNames() {
         TestLogger logger1 = getInstance().getLogger("name1");
         TestLogger logger2 = getInstance().getLogger("name1");
 
@@ -52,7 +48,7 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void staticGetTestLoggerStringReturnsSame() {
+    void staticGetTestLoggerStringReturnsSame() {
         TestLogger logger1 = TestLoggerFactory.getTestLogger("name1");
         TestLogger logger2 = getInstance().getLogger("name1");
 
@@ -60,7 +56,7 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void staticGetTestLoggerClassReturnsSame() {
+    void staticGetTestLoggerClassReturnsSame() {
         TestLogger logger1 = TestLoggerFactory.getTestLogger(String.class);
         TestLogger logger2 = getInstance().getLogger("java.lang.String");
 
@@ -68,7 +64,7 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void clear() {
+    void clear() {
         TestLogger logger1 = getInstance().getLogger("name1");
         logger1.trace("hello");
         assertThat(logger1.getLoggingEvents().size(), is(1));
@@ -84,7 +80,7 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void getAllLoggingEvents() {
+    void getAllLoggingEvents() {
         TestLogger logger1 = getInstance().getLogger("name1");
         TestLogger logger2 = getInstance().getLogger("name2");
         logger1.trace("hello");
@@ -98,7 +94,7 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void getAllLoggingEventsDoesNotAddToMultipleLoggers() {
+    void getAllLoggingEventsDoesNotAddToMultipleLoggers() {
         TestLogger logger1 = getInstance().getLogger("name1");
         TestLogger logger2 = getInstance().getLogger("name2");
         logger1.trace("hello");
@@ -109,7 +105,7 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void getAllLoggingEventsDoesNotGetEventsForLoggersNotEnabled() {
+    void getAllLoggingEventsDoesNotGetEventsForLoggersNotEnabled() {
         TestLogger logger = getInstance().getLogger("name1");
         logger.setEnabledLevels(WARN);
         logger.info("hello");
@@ -118,7 +114,7 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void getAllTestLoggers() {
+    void getAllTestLoggers() {
         TestLogger logger1 = getInstance().getLogger("name1");
         TestLogger logger2 = getInstance().getLogger("name2");
         Map<String, TestLogger> expected = new HashMap<>();
@@ -128,7 +124,7 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void clearDoesNotRemoveLoggers() {
+    void clearDoesNotRemoveLoggers() {
         TestLogger logger1 = getInstance().getLogger("name1");
         TestLoggerFactory.clear();
 
@@ -137,7 +133,7 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void resetRemovesAllLoggers() {
+    void resetRemovesAllLoggers() {
         getInstance().getLogger("name1");
 
         TestLoggerFactory.reset();
@@ -147,7 +143,7 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void resetRemovesAllLoggingEvents() {
+    void resetRemovesAllLoggingEvents() {
         getInstance().getLogger("name1").info("hello");
 
         TestLoggerFactory.reset();
@@ -156,7 +152,7 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void getLoggingEventsReturnsCopyNotView() {
+    void getLoggingEventsReturnsCopyNotView() {
         getInstance().getLogger("name1").debug("hello");
         List<LoggingEvent> loggingEvents = TestLoggerFactory.getLoggingEvents();
         getInstance().getLogger("name1").info("world");
@@ -164,14 +160,14 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void getLoggingEventsReturnsUnmodifiableList() {
+    void getLoggingEventsReturnsUnmodifiableList() {
         List<LoggingEvent> loggingEvents = TestLoggerFactory.getLoggingEvents();
         LoggingEvent loggingEvent = debug("hello");
         assertThrows(UnsupportedOperationException.class, () -> loggingEvents.add(loggingEvent));
     }
 
     @Test
-    public void getAllLoggersReturnsCopyNotView() {
+    void getAllLoggersReturnsCopyNotView() {
         TestLogger logger1 = getInstance().getLogger("name1");
         Map<String, TestLogger> allTestLoggers = TestLoggerFactory.getAllTestLoggers();
         getInstance().getLogger("name2");
@@ -180,7 +176,7 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void getAllLoggersReturnsUnmodifiableList() {
+    void getAllLoggersReturnsUnmodifiableList() {
         Map<String, TestLogger> allTestLoggers = TestLoggerFactory.getAllTestLoggers();
         TestLogger newLogger = new TestLogger("newlogger", getInstance());
         assertThrows(
@@ -188,7 +184,7 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void getLoggingEventsOnlyReturnsEventsLoggedInThisThread() throws InterruptedException {
+    void getLoggingEventsOnlyReturnsEventsLoggedInThisThread() throws InterruptedException {
         Thread t = new Thread(() -> TestLoggerFactory.getTestLogger("name1").info("hello"));
         t.start();
         t.join();
@@ -196,7 +192,7 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void getAllLoggingEventsReturnsEventsLoggedInAllThreads() throws InterruptedException {
+    void getAllLoggingEventsReturnsEventsLoggedInAllThreads() throws InterruptedException {
         Thread t = new Thread(() -> TestLoggerFactory.getTestLogger("name1").info("message1"));
         t.start();
         t.join();
@@ -206,7 +202,7 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void clearOnlyClearsEventsLoggedInThisThread() throws InterruptedException {
+    void clearOnlyClearsEventsLoggedInThisThread() throws InterruptedException {
         final TestLogger logger = TestLoggerFactory.getTestLogger("name");
         Thread t = new Thread(() -> logger.info("hello"));
         t.start();
@@ -216,7 +212,7 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void clearAllClearsEventsLoggedInAllThreads() throws InterruptedException {
+    void clearAllClearsEventsLoggedInAllThreads() throws InterruptedException {
         final TestLogger logger1 = TestLoggerFactory.getTestLogger("name1");
         final TestLogger logger2 = TestLoggerFactory.getTestLogger("name2");
         logger1.info("hello11");
@@ -239,31 +235,28 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void defaultPrintLevelIsOff() {
+    void defaultPrintLevelIsOff() {
         assertThat(getInstance().getPrintLevel(), is(nullValue()));
     }
 
     @Test
-    @PrepareForTest(TestLoggerFactory.class)
-    public void printLevelTakenFromOverridableProperties() throws Exception {
+    void printLevelTakenFromOverridableProperties() throws Exception {
         final OverridableProperties properties = mock(OverridableProperties.class);
-        whenNew(OverridableProperties.class).withArguments("slf4jtest").thenReturn(properties);
         when(properties.getProperty("print.level", "OFF")).thenReturn("INFO");
         when(properties.getProperty("capture.level", "TRACE")).thenReturn("INFO");
 
-        assertThat(getInstance().getPrintLevel(), is(Level.INFO));
+        assertThat(TestLoggerFactory.createInstance(properties).getPrintLevel(), is(Level.INFO));
     }
 
     @Test
-    @PrepareForTest(TestLoggerFactory.class)
-    public void printLevelInvalidInOverridableProperties() throws Exception {
+    void printLevelInvalidInOverridableProperties() throws Exception {
         final OverridableProperties properties = mock(OverridableProperties.class);
-        whenNew(OverridableProperties.class).withArguments("slf4jtest").thenReturn(properties);
         final String invalidLevelName = "nonsense";
         when(properties.getProperty("print.level", "OFF")).thenReturn(invalidLevelName);
 
         final IllegalStateException illegalStateException =
-                assertThrows(IllegalStateException.class, TestLoggerFactory::getInstance);
+                assertThrows(
+                        IllegalStateException.class, () -> TestLoggerFactory.createInstance(properties));
         assertThat(
                 illegalStateException.getMessage(),
                 is(
@@ -276,32 +269,29 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    public void defaultCaptureLevelIsTrace() {
+    void defaultCaptureLevelIsTrace() {
         assertThat(getInstance().getCaptureLevel(), is(Level.TRACE));
     }
 
     @Test
-    @PrepareForTest(TestLoggerFactory.class)
-    public void captureLevelTakenFromOverridableProperties() throws Exception {
+    void captureLevelTakenFromOverridableProperties() throws Exception {
         final OverridableProperties properties = mock(OverridableProperties.class);
-        whenNew(OverridableProperties.class).withArguments("slf4jtest").thenReturn(properties);
         when(properties.getProperty("print.level", "OFF")).thenReturn("INFO");
         when(properties.getProperty("capture.level", "TRACE")).thenReturn("INFO");
 
-        assertThat(getInstance().getCaptureLevel(), is(Level.INFO));
+        assertThat(TestLoggerFactory.createInstance(properties).getCaptureLevel(), is(Level.INFO));
     }
 
     @Test
-    @PrepareForTest(TestLoggerFactory.class)
-    public void captureLevelInvalidInOverridableProperties() throws Exception {
+    void captureLevelInvalidInOverridableProperties() throws Exception {
         final OverridableProperties properties = mock(OverridableProperties.class);
-        whenNew(OverridableProperties.class).withArguments("slf4jtest").thenReturn(properties);
         when(properties.getProperty("print.level", "OFF")).thenReturn("INFO");
         final String invalidLevelName = "nonsense";
         when(properties.getProperty("capture.level", "TRACE")).thenReturn(invalidLevelName);
 
         final IllegalStateException illegalStateException =
-                assertThrows(IllegalStateException.class, TestLoggerFactory::getInstance);
+                assertThrows(
+                        IllegalStateException.class, () -> TestLoggerFactory.createInstance(properties));
         assertThat(
                 illegalStateException.getMessage(),
                 is(
@@ -314,26 +304,29 @@ public class TestLoggerFactoryTests {
     }
 
     @Test
-    @PrepareForTest(TestLoggerFactory.class)
-    public void ioExceptionAtPropertiesLoading() throws Exception {
-        IOException ioException = new IOException();
-        whenNew(OverridableProperties.class).withArguments("slf4jtest").thenThrow(ioException);
-
-        final UncheckedIOException uncheckedIOException =
-                assertThrows(UncheckedIOException.class, TestLoggerFactory::getInstance);
-        assertThat(uncheckedIOException.getCause(), is(ioException));
-    }
-
-    @Test
-    public void setLevel() {
+    void setLevel() {
         for (Level printLevel : Level.values()) {
             getInstance().setPrintLevel(printLevel);
             assertThat(getInstance().getPrintLevel(), is(printLevel));
         }
     }
 
-    @After
-    public void resetLoggerFactory() {
+    @Test
+    void defaultConstructor() {
+        TestLoggerFactory testLoggerFactory = new TestLoggerFactory();
+        assertEquals(Level.TRACE, testLoggerFactory.getCaptureLevel(), "capture level");
+        assertNull(testLoggerFactory.getPrintLevel(), "print level");
+    }
+
+    @Test
+    void oneArgConstructor() {
+        TestLoggerFactory testLoggerFactory = new TestLoggerFactory(Level.INFO);
+        assertEquals(Level.TRACE, testLoggerFactory.getCaptureLevel(), "capture level");
+        assertEquals(Level.INFO, testLoggerFactory.getPrintLevel(), "print level");
+    }
+
+    @AfterEach
+    void resetLoggerFactory() {
         try {
             TestLoggerFactory.reset();
             getInstance().setPrintLevel(null);

--- a/src/test/java/com/github/valfirst/slf4jtest/TestMDCAdapterTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestMDCAdapterTests.java
@@ -1,13 +1,23 @@
 package com.github.valfirst.slf4jtest;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
 
 class TestMDCAdapterTests {
 
@@ -15,13 +25,81 @@ class TestMDCAdapterTests {
     private final String key = "key";
     private final String value = "value";
 
+    @AfterEach
+    void afterEach() {
+        testMDCAdapter.restoreOptions();
+        testMDCAdapter.clear();
+    }
+
     @Test
     void putGetRemoveLoop() {
         assertNull(testMDCAdapter.get(key));
+        testMDCAdapter.remove(key);
         testMDCAdapter.put(key, value);
         assertEquals(value, testMDCAdapter.get(key));
         testMDCAdapter.remove(key);
         assertNull(testMDCAdapter.get(key));
+    }
+
+    @Test
+    void putGetTwoKeys() {
+        testMDCAdapter.put(key, value);
+        testMDCAdapter.put("Another", "Value");
+        assertEquals(value, testMDCAdapter.get(key));
+        assertEquals("Value", testMDCAdapter.get("Another"));
+    }
+
+    @Test
+    void testPutNullKeyThrowsIllegalArgumentException() {
+        IllegalArgumentException illegalArgumentException =
+                assertThrows(IllegalArgumentException.class, () -> testMDCAdapter.put(null, value));
+        assertEquals("key cannot be null", illegalArgumentException.getMessage());
+    }
+
+    @Test
+    void testPutNullValueThrowsIllegalArgumentExceptionIfForbidden() {
+        testMDCAdapter.setAllowNullValues(false);
+        IllegalArgumentException illegalArgumentException =
+                assertThrows(IllegalArgumentException.class, () -> testMDCAdapter.put(key, null));
+        assertEquals("val cannot be null", illegalArgumentException.getMessage());
+    }
+
+    @Test
+    void testPutNullValueDoesNotThrowIfAllowed() {
+        testMDCAdapter.setAllowNullValues(true);
+        assertDoesNotThrow(() -> testMDCAdapter.put(key, null));
+    }
+
+    @Test
+    void testPutNullKeyValueDoesNotThrowIfNotEnabled() {
+        testMDCAdapter.setEnable(false);
+        assertDoesNotThrow(() -> testMDCAdapter.put(key, null));
+    }
+
+    @Test
+    void testGetNullKeyThrowsIllegalArgumentException() {
+        IllegalArgumentException illegalArgumentException =
+                assertThrows(IllegalArgumentException.class, () -> testMDCAdapter.get(null));
+        assertEquals("key cannot be null", illegalArgumentException.getMessage());
+    }
+
+    @Test
+    void testGetReturnsNullIfNotEnabled() {
+        testMDCAdapter.setEnable(false);
+        assertNull(testMDCAdapter.get(null));
+    }
+
+    @Test
+    void removeNullKeyThrowsIllegalArgumentException() {
+        IllegalArgumentException illegalArgumentException =
+                assertThrows(IllegalArgumentException.class, () -> testMDCAdapter.remove(null));
+        assertEquals("key cannot be null", illegalArgumentException.getMessage());
+    }
+
+    @Test
+    void testRemoveNullKeyDoesNotThrowIfNotEnabled() {
+        testMDCAdapter.setEnable(false);
+        assertDoesNotThrow(() -> testMDCAdapter.remove(null));
     }
 
     @Test
@@ -39,10 +117,28 @@ class TestMDCAdapterTests {
     }
 
     @Test
+    void getCopyOfContextMapReturnsNullWhenSet() {
+        testMDCAdapter.setReturnNullCopyWhenMdcNotSet(true);
+        assertNull(testMDCAdapter.getCopyOfContextMap());
+    }
+
+    @Test
+    void getCopyOfContextMapReturnsNullWhenNotEnabled() {
+        testMDCAdapter.setEnable(false);
+        assertNull(testMDCAdapter.getCopyOfContextMap());
+    }
+
+    @Test
     void clear() {
         testMDCAdapter.put(key, value);
         testMDCAdapter.clear();
         assertEquals(Collections.emptyMap(), testMDCAdapter.getCopyOfContextMap());
+    }
+
+    @Test
+    void clearWhenNotEnabled() {
+        testMDCAdapter.setEnable(false);
+        testMDCAdapter.clear();
     }
 
     @Test
@@ -56,9 +152,59 @@ class TestMDCAdapterTests {
     }
 
     @Test
+    void setContextMapNotEnabled() {
+        testMDCAdapter.setEnable(false);
+        Map<String, String> newValues = new HashMap<>();
+        newValues.put(key, value);
+        testMDCAdapter.setContextMap(newValues);
+    }
+
+    @Test
+    void testElementNullKeyThrowsIllegalArgumentException() {
+        final Map<String, String> map = new HashMap<>();
+        map.put(null, value);
+        IllegalArgumentException illegalArgumentException =
+                assertThrows(IllegalArgumentException.class, () -> testMDCAdapter.setContextMap(map));
+        assertEquals("key cannot be null", illegalArgumentException.getMessage());
+    }
+
+    @Test
+    void testElementNullValueThrowsIllegalArgumentExceptionIfForbidden() {
+        testMDCAdapter.setAllowNullValues(false);
+        final Map<String, String> map = new HashMap<>();
+        map.put(key, null);
+        IllegalArgumentException illegalArgumentException =
+                assertThrows(IllegalArgumentException.class, () -> testMDCAdapter.setContextMap(map));
+        assertEquals("val cannot be null", illegalArgumentException.getMessage());
+    }
+
+    @Test
+    void testElementNullValueDoesNotThrowIfAllowed() {
+        testMDCAdapter.setAllowNullValues(true);
+        final Map<String, String> map = new HashMap<>();
+        map.put(key, null);
+        assertDoesNotThrow(() -> testMDCAdapter.setContextMap(map));
+    }
+
+    @Test
+    void testElementNonNullValueDoesNotThrowIfForbidden() {
+        testMDCAdapter.setAllowNullValues(false);
+        final Map<String, String> map = new HashMap<>();
+        map.put(key, value);
+        assertDoesNotThrow(() -> testMDCAdapter.setContextMap(map));
+    }
+
+    @Test
+    void testSetNullMapClearsMdc() {
+        testMDCAdapter.put(key, value);
+        testMDCAdapter.setContextMap(null);
+        assertEquals(Collections.emptyMap(), testMDCAdapter.getCopyOfContextMap());
+    }
+
+    @Test
     void testMdcAdapterIsThreadLocal() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(2);
-        final Map<String, String> results = new HashMap<>();
+        final Map<String, String> results = Collections.synchronizedMap(new HashMap<>());
         Thread thread1 =
                 new Thread(
                         () -> {
@@ -89,5 +235,139 @@ class TestMDCAdapterTests {
         thread2.join();
         assertEquals("value1", results.get("thread1"));
         assertEquals("value2", results.get("thread2"));
+    }
+
+    @Test
+    void testMdcAdapterIsInheritedWhenSet() throws InterruptedException {
+        testMDCAdapter.setInherit(true);
+        testMDCAdapter.put(key, value);
+        final AtomicReference<String> result = new AtomicReference<>();
+        Thread thread =
+                new Thread(
+                        () -> {
+                            result.set(testMDCAdapter.get(key));
+                        });
+        thread.start();
+        thread.join();
+        assertEquals(value, result.get());
+    }
+
+    @Test
+    void testMdcAdapterIsNotInheritedWhenNotSet() throws InterruptedException {
+        testMDCAdapter.setInherit(false);
+        testMDCAdapter.put(key, value);
+        final AtomicReference<String> result = new AtomicReference<>(value);
+        Thread thread =
+                new Thread(
+                        () -> {
+                            result.set(testMDCAdapter.get(key));
+                        });
+        thread.start();
+        thread.join();
+        assertNull(result.get());
+    }
+
+    @Test
+    void testMdcAdapterNothingIsInheritedWhenSet() throws InterruptedException {
+        testMDCAdapter.setInherit(true);
+        final AtomicReference<String> result = new AtomicReference<>(value);
+        Thread thread =
+                new Thread(
+                        () -> {
+                            result.set(testMDCAdapter.get(key));
+                        });
+        thread.start();
+        thread.join();
+        assertNull(result.get());
+    }
+
+    @Test
+    void testGetInstanceReturnsMDC() {
+        assertSame(MDC.getMDCAdapter(), TestMDCAdapter.getInstance());
+    }
+
+    @Test
+    void testDefaultOptions() {
+        assertEquals(
+                new TestMDCAdapterOptions(true, false, false, true),
+                new TestMDCAdapterOptions(testMDCAdapter));
+    }
+
+    @Test
+    void testOptionsCanBeSetToTrue() throws Exception {
+        final OverridableProperties properties = mock(OverridableProperties.class);
+        when(properties.getProperty(anyString(), anyString())).thenReturn("true");
+        TestMDCAdapter localTestMDCAdapter = new TestMDCAdapter(properties);
+        assertEquals(
+                new TestMDCAdapterOptions(true, true, true, true),
+                new TestMDCAdapterOptions(localTestMDCAdapter));
+    }
+
+    @Test
+    void testOptionsCanBeSetToFalse() throws Exception {
+        final OverridableProperties properties = mock(OverridableProperties.class);
+        when(properties.getProperty(anyString(), anyString())).thenReturn("false");
+        TestMDCAdapter localTestMDCAdapter = new TestMDCAdapter(properties);
+        assertEquals(
+                new TestMDCAdapterOptions(false, false, false, false),
+                new TestMDCAdapterOptions(localTestMDCAdapter));
+    }
+
+    private static class TestMDCAdapterOptions {
+        private final boolean enable;
+        private final boolean inherit;
+        private final boolean returnNullCopyWhenMdcNotSet;
+        private final boolean allowNullValues;
+
+        public TestMDCAdapterOptions(
+                boolean enable,
+                boolean inherit,
+                boolean returnNullCopyWhenMdcNotSet,
+                boolean allowNullValues) {
+            this.enable = enable;
+            this.inherit = inherit;
+            this.allowNullValues = allowNullValues;
+            this.returnNullCopyWhenMdcNotSet = returnNullCopyWhenMdcNotSet;
+        }
+
+        public TestMDCAdapterOptions(TestMDCAdapter testMDCAdapter) {
+            this(
+                    testMDCAdapter.getEnable(),
+                    testMDCAdapter.getInherit(),
+                    testMDCAdapter.getReturnNullCopyWhenMdcNotSet(),
+                    testMDCAdapter.getAllowNullValues());
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (!(other instanceof TestMDCAdapterOptions)) return false;
+            TestMDCAdapterOptions that = (TestMDCAdapterOptions) other;
+            Object[] ours = {enable, inherit, returnNullCopyWhenMdcNotSet, allowNullValues};
+            Object[] theirs = {
+                that.enable, that.inherit, that.returnNullCopyWhenMdcNotSet, that.allowNullValues
+            };
+            return Arrays.equals(ours, theirs);
+        }
+
+        @Override
+        public int hashCode() {
+            Object[] ours = {enable, inherit, returnNullCopyWhenMdcNotSet, allowNullValues};
+            return Arrays.hashCode(ours);
+        }
+
+        @Override
+        public String toString() {
+            return "TestMDCAdapterOptions:{"
+                    + "enable:"
+                    + String.valueOf(enable)
+                    + ",inherit:"
+                    + String.valueOf(inherit)
+                    + ",returnNullCopyWhenMdcNotSet:"
+                    + String.valueOf(returnNullCopyWhenMdcNotSet)
+                    + ",allowNullValues:"
+                    + String.valueOf(allowNullValues)
+                    + "}";
+        }
     }
 }


### PR DESCRIPTION
This PR solves issue #392.

As I worked on it, it turned out that there are other aspects of the MDC adapter behaviour that need to be configurable. As documented in `usage.md`, there is now configuration for four aspects:

* Whether an MDC is supported at all.
* Whether the MDC is inherited by child threads. This was the original task.
* Whether `getCopyOfContextMap()` shall return an empty map or null if the MDC has not been set.
* Whether null is a legal value in an MDC entry. Null keys are never allowed.

With so many options, it quickly became clear that a thorough testing would involve heavy use of PowerMock, and thus become very slow. I split the `TestMDCAdapter` constructor in two:

* A package-private constructor that takes an `OverridableProperties` argument and does most of the work
* A public default constructor that creates a new `OverridableProperties` object and delegates to the first.

I added a static method `createUnchecked` to `OverridableProperties` that creates the object, and catches the `IOException` and rethrows it as an `UncheckedIOException`, with code taken from the `TestLoggerFactory` constructor. This method is used in the `TestMDCAdapter` default constructor.

In this way, I could create separate `TestMDCAdapter` instances for testing, mocking the configuration as needed without the need for PowerMock.

I had a case where the test `TestMDCAdapterTests.testMdcAdapterIsThreadLocal()` failed, probably due to a race condition. I wrapped the map used to store the result with `Collections.synchronizedMap()`. I did not see the problem since then.

I then decided to refactor the creation of the `TestLoggerFactory` instance in the same way. This meant that I could avoid the use of PowerMock in `TestLoggerFactoryTests`, reducing the total `mvn clean verify` build time by 45% in my setup. Only the
test of handling of `IOException` in the creation method in `OverridableProperties` now uses PowerMock. This is the second commit on the branch.