### PR TITLE
Add utility classes to support java.util.logging testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,12 @@
             <version>${slf4j.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.24.2</version>

--- a/src/main/java/com/github/valfirst/slf4jtest/JulConfig.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/JulConfig.java
@@ -1,0 +1,31 @@
+package com.github.valfirst.slf4jtest;
+
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+/**
+ * Configuration to redirect log messages from {@link java.util.logging} to SLF4J.
+ *
+ * @author Karsten Spang
+ */
+public class JulConfig {
+
+    /**
+     * Redirect all logging from {@link java.util.logging} to SLF4J. If called more than once, it will
+     * do nothing on subsequent calls.
+     */
+    public static void setup() {
+        if (!SLF4JBridgeHandler.isInstalled()) {
+            synchronized (JulConfig.class) {
+                if (!SLF4JBridgeHandler.isInstalled()) {
+                    SLF4JBridgeHandler.removeHandlersForRootLogger();
+                    SLF4JBridgeHandler.install();
+                    LogManager.getLogManager().getLogger("").setLevel(Level.ALL);
+                }
+            }
+        }
+    }
+
+    private JulConfig() {}
+}

--- a/src/main/java/com/github/valfirst/slf4jtest/JulConfigExtension.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/JulConfigExtension.java
@@ -1,0 +1,17 @@
+package com.github.valfirst.slf4jtest;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * JUnit 5 extension that calls {@link JulConfig#setup()}.
+ *
+ * @author Karsten Spang
+ */
+public class JulConfigExtension implements BeforeAllCallback {
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) {
+        JulConfig.setup();
+    }
+}

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -149,3 +149,42 @@ Place a file called slf4jtest.properties on the classpath with the following
 line in it:
 
     print.level=INFO
+
+### Testing Code Using java.util.logging
+Although this module is named SLF4J Test, it can be used to test code using
+other test API's as well. In most cases, it is just a matter of placing the
+proper bridge on the test classpath, see e.g.
+[Bridging legacy APIs](https://www.slf4j.org/legacy.html).
+But in case of java.util.logging, there is a little more work than adding
+`jul-to-slf4j` to the classpath. Normally,
+an application will create a `logging.properties` file containing
+
+    handlers = org.slf4j.bridge.SLF4JBridgeHandler
+
+and set the system property `java.util.logging.config.file` on the
+command line to the full path of the file. But this is not
+practical for running unit tests. Instead, the configuration is done
+programatically in the test code.
+
+SLF4J Test has code to make this easier. Calling
+[`JulConfig.setup()`](apidocs/com/github/valfirst/slf4jtest/JulConfig.html#setup--)
+will do this for you. You should call this method before running any
+test that requires java.util.logging to be configured. Calling this method more
+than once has no effect, so you can safely call it before tests in all test
+suites with this requirement, e.g. in a `@BeforeClass` method if using Junit 4.
+
+If you use Junit 5, it is even easier. There is a Junit 5 extension
+[`JulConfigExtension`](apidocs/apidocs/com/github/valfirst/slf4jtest/JulConfigExtension.html.html)
+doing this declaratively. For example
+
+    import com.github.valfirst.slf4jtest.JulConfigExtension;
+    import org.junit.jupiter.api.extension.ExtendWith;
+    
+    @ExtendWith(JulConfigExtension.class)
+    class JulLoggingTests {
+        @Test
+        void testJulLogging() {
+            ...
+        }
+        ...
+    }

--- a/src/test/java/com/github/valfirst/slf4jtest/JulConfigTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/JulConfigTests.java
@@ -1,0 +1,52 @@
+package com.github.valfirst.slf4jtest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+class JulConfigTests {
+
+    private static String message = "message";
+
+    @BeforeEach
+    void beforeEach() {
+        SLF4JBridgeHandler.uninstall();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        SLF4JBridgeHandler.uninstall();
+    }
+
+    @Test
+    void testExtension() {
+        new JulConfigExtension().beforeAll(null);
+        assertTrue(SLF4JBridgeHandler.isInstalled());
+    }
+
+    @Test
+    void testSetupTwice() {
+        JulConfig.setup();
+        JulConfig.setup();
+        assertTrue(SLF4JBridgeHandler.isInstalled());
+    }
+
+    @Test
+    void testLogging() {
+        JulConfig.setup();
+        Logger logger = Logger.getLogger(JulConfigTests.class.getName());
+        TestLogger testLogger = TestLoggerFactory.getTestLogger(JulConfigTests.class);
+        testLogger.clear();
+        logger.fine(message);
+        List<LoggingEvent> events = testLogger.getLoggingEvents();
+        List<LoggingEvent> expected = Arrays.asList(LoggingEvent.debug(message));
+        assertEquals(expected, events);
+    }
+}


### PR DESCRIPTION
This PR resolves the issue: Helper class for testing java.util.logging code #400.

It adds a helper class to do the java.util.logging setup, as well as a Junit 5 extension that calls it.

It adds the jul-to-slf4j bridge as an optional dependency.