### PR TITLE
Fix #393 Setting enabled logging levels for all threads change the default for all threads

### DIFF
--- a/src/main/java/com/github/valfirst/slf4jtest/TestLogger.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLogger.java
@@ -46,8 +46,10 @@ public class TestLogger implements Logger {
     private final ThreadLocal<List<LoggingEvent>> loggingEvents = new ThreadLocal<>(ArrayList::new);
 
     private final List<LoggingEvent> allLoggingEvents = new CopyOnWriteArrayList<>();
-    private volatile ThreadLocal<Set<Level>> enabledLevels =
-            new ThreadLocal<>(Collections.unmodifiableSet(EnumSet.allOf(Level.class)));
+
+    private static final Set<Level> allLevels =
+            Collections.unmodifiableSet(EnumSet.allOf(Level.class));
+    private volatile ThreadLocal<Set<Level>> enabledLevels = new ThreadLocal<>(allLevels);
 
     TestLogger(final String name, final TestLoggerFactory testLoggerFactory) {
         this.name = name;
@@ -64,7 +66,7 @@ public class TestLogger implements Logger {
      */
     public void clear() {
         loggingEvents.get().clear();
-        enabledLevels.remove();
+        enabledLevels.set(allLevels);
     }
 
     /**
@@ -75,6 +77,7 @@ public class TestLogger implements Logger {
         allLoggingEvents.clear();
         loggingEvents.reset();
         enabledLevels.reset();
+        enabledLevels = new ThreadLocal<>(allLevels);
     }
 
     /**
@@ -512,12 +515,6 @@ public class TestLogger implements Logger {
      * being enabled, is not a requirement of the SLF4J API, so all levels you wish to enable must be
      * passed explicitly to this method.
      *
-     * <p>Note that this modifies the default enabled levels in all threads. After calling this
-     * method, {@link #clear()} and {@link #clearAll()} will set the enabled levels to the value
-     * passed to this method, not all levels. You will have to call this method with {@code
-     * EnumSet.allOf(Level.class)} (or {@link #setEnabledLevelsForAllThreads(Level...)} with all the
-     * levels) to return to standard behaviour.
-     *
      * @param enabledLevelsForAllThreads levels which will be considered enabled for this logger IN
      *     ALL THREADS
      */
@@ -529,12 +526,6 @@ public class TestLogger implements Logger {
      * The conventional hierarchical notion of Levels, where info being enabled implies warn and error
      * being enabled, is not a requirement of the SLF4J API, so all levels you wish to enable must be
      * passed explicitly to this method.
-     *
-     * <p>Note that this modifies the default enabled levels in all threads. After calling this
-     * method, {@link #clear()} and {@link #clearAll()} will set the enabled levels to the value
-     * passed to this method, not all levels. You will have to call this method with all levels (or
-     * {@link #setEnabledLevelsForAllThreads(Collection)} with {@code EnumSet.allOf(Level.class)}) to
-     * return to standard behaviour.
      *
      * @param enabledLevelsForAllThreads levels which will be considered enabled for this logger IN
      *     ALL THREADS

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerTests.java
@@ -783,6 +783,22 @@ class TestLoggerTests {
         assertEquals(EnumSet.allOf(Level.class), testLogger.getEnabledLevels());
     }
 
+    @Test
+    void clearAllChangesAllLevelsAllThreads() throws Exception {
+        testLogger.setEnabledLevelsForAllThreads(WARN, ERROR);
+        Thread t = new Thread(testLogger::clearAll);
+        t.start();
+        t.join();
+        assertEquals(EnumSet.allOf(Level.class), testLogger.getEnabledLevels());
+    }
+
+    @Test
+    void clearChangesLevelsAllThreads() throws Exception {
+        testLogger.setEnabledLevelsForAllThreads(WARN, ERROR);
+        testLogger.clear();
+        assertEquals(EnumSet.allOf(Level.class), testLogger.getEnabledLevels());
+    }
+
     @ParameterizedTest
     @EnumSource(names = {"INFO", "DEBUG", "TRACE"})
     @StdIo


### PR DESCRIPTION
This closes #393 Setting enabled logging levels for all threads change the default for all threads

Changing `TestLogger.setEnabledLevelsForAllThreads` as I originally intended turned out to be logically impossible, so I restricted the changes to make `TestLogger.clear` and `TestLogger.clearAll` to behave like their Javadoc says, even after `setEnabledLevelsForAllThreads` has been called.
I also updated the Javadoc for `setEnabledLevelsForAllThreads`, removing the note that calling these methods makes `clear` and `clearAll` not behave as expected.

I added two new test cases that fail for the unchanged code.