### PR TITLE
Avoid excessive copying of the MDC

### DIFF
--- a/src/main/java/com/github/valfirst/slf4jtest/LoggingEvent.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/LoggingEvent.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.SortedMap;
 import java.util.TreeMap;
 import org.slf4j.Marker;
 import org.slf4j.event.Level;
@@ -46,7 +47,7 @@ public class LoggingEvent {
             new DateTimeFormatterBuilder().appendInstant(3).toFormatter();
 
     private final Level level;
-    private final Map<String, String> mdc;
+    private final SortedMap<String, String> mdc;
     private final Optional<Marker> marker;
     private final Optional<Throwable> throwable;
     private final String message;
@@ -319,7 +320,7 @@ public class LoggingEvent {
     }
 
     public LoggingEvent(final Level level, final String message, final Object... arguments) {
-        this(level, Collections.emptyMap(), empty(), empty(), message, arguments);
+        this(level, Collections.emptySortedMap(), empty(), empty(), message, arguments);
     }
 
     public LoggingEvent(
@@ -327,12 +328,12 @@ public class LoggingEvent {
             final Throwable throwable,
             final String message,
             final Object... arguments) {
-        this(level, Collections.emptyMap(), empty(), ofNullable(throwable), message, arguments);
+        this(level, Collections.emptySortedMap(), empty(), ofNullable(throwable), message, arguments);
     }
 
     public LoggingEvent(
             final Level level, final Marker marker, final String message, final Object... arguments) {
-        this(level, Collections.emptyMap(), ofNullable(marker), empty(), message, arguments);
+        this(level, Collections.emptySortedMap(), ofNullable(marker), empty(), message, arguments);
     }
 
     public LoggingEvent(
@@ -343,7 +344,7 @@ public class LoggingEvent {
             final Object... arguments) {
         this(
                 level,
-                Collections.emptyMap(),
+                Collections.emptySortedMap(),
                 ofNullable(marker),
                 ofNullable(throwable),
                 message,
@@ -408,7 +409,9 @@ public class LoggingEvent {
         this.creatingLogger = creatingLogger;
         this.level = requireNonNull(level);
         this.mdc =
-                mdc == null ? Collections.emptyMap() : Collections.unmodifiableMap(new TreeMap<>(mdc));
+                mdc.isEmpty()
+                        ? Collections.emptySortedMap()
+                        : Collections.unmodifiableSortedMap(new TreeMap<>(mdc));
         this.marker = requireNonNull(marker);
         this.throwable = requireNonNull(throwable);
         this.message = message;
@@ -420,10 +423,13 @@ public class LoggingEvent {
     }
 
     /**
-     * Get the MDC of the event. This is a copy of the MDC when the event was created. The returned
-     * value is an unmodifiable {@link java.util.SortedMap} with natural ordering of the keys.
+     * Get the MDC of the event. For events created by {@link TestLogger}, this is an unmodifiable
+     * copy of the MDC of the the thread when the event was created. For events constructed directly,
+     * this is unmodifiable copy of the MDC passed to the constructor, if any. If no MDC was used for
+     * construction, the copy is an empty map. The copy is a {@link SortedMap}, in order to make it
+     * easier to spot discrepancies in case an assertion fails. Natural ordering of the keys is used.
      */
-    public Map<String, String> getMdc() {
+    public SortedMap<String, String> getMdc() {
         return mdc;
     }
 

--- a/src/main/java/com/github/valfirst/slf4jtest/LoggingEvent.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/LoggingEvent.java
@@ -409,7 +409,7 @@ public class LoggingEvent {
         this.creatingLogger = creatingLogger;
         this.level = requireNonNull(level);
         this.mdc =
-                mdc.isEmpty()
+                requireNonNull(mdc).isEmpty()
                         ? Collections.emptySortedMap()
                         : Collections.unmodifiableSortedMap(new TreeMap<>(mdc));
         this.marker = requireNonNull(marker);

--- a/src/main/java/com/github/valfirst/slf4jtest/TestLogger.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLogger.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.slf4j.Logger;
-import org.slf4j.MDC;
 import org.slf4j.Marker;
 import org.slf4j.event.Level;
 import org.slf4j.helpers.FormattingTuple;
@@ -467,7 +466,7 @@ public class TestLogger implements Logger {
     }
 
     private Map<String, String> mdc() {
-        return ofNullable(MDC.getCopyOfContextMap()).orElseGet(Collections::emptyMap);
+        return TestMDCAdapter.getInstance().getContextMap();
     }
 
     private void optionallyPrint(final LoggingEvent event) {

--- a/src/main/java/com/github/valfirst/slf4jtest/TestMDCAdapter.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestMDCAdapter.java
@@ -3,6 +3,7 @@ package com.github.valfirst.slf4jtest;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import org.slf4j.MDC;
 import org.slf4j.helpers.BasicMDCAdapter;
 
@@ -110,10 +111,10 @@ public class TestMDCAdapter extends BasicMDCAdapter {
             if (returnNullCopyWhenMdcNotSet) {
                 return null;
             } else {
-                return new HashMap<>();
+                return new TreeMap<>();
             }
         } else {
-            return new HashMap<>(map);
+            return new TreeMap<>(map);
         }
     }
 

--- a/src/main/java/com/github/valfirst/slf4jtest/TestMDCAdapter.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestMDCAdapter.java
@@ -3,8 +3,6 @@ package com.github.valfirst.slf4jtest;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import org.slf4j.MDC;
 import org.slf4j.helpers.BasicMDCAdapter;
 
@@ -94,9 +92,7 @@ public class TestMDCAdapter extends BasicMDCAdapter {
     }
 
     /**
-     * Return a copy of the current thread's context map. It is a {@link SortedMap}, using the natural
-     * order of the keys. This makes it easier to spot discrepancies if an assertion fails. The
-     * returned map is unmodifiable. {@code null} is returned if
+     * Return a copy of the current thread's context map. {@code null} is returned if
      *
      * <ul>
      *   <li>The MDC functionality is disabled, c.f. <code>setEnable</code>, or
@@ -114,20 +110,24 @@ public class TestMDCAdapter extends BasicMDCAdapter {
             if (returnNullCopyWhenMdcNotSet) {
                 return null;
             } else {
-                return Collections.emptyMap();
+                return new HashMap<>();
             }
         } else {
-            return Collections.unmodifiableMap(new TreeMap<>(map));
+            return new HashMap<>(map);
         }
+    }
+
+    // Internal access
+    Map<String, String> getContextMap() {
+        Map<String, String> map = value.get();
+        return map == null ? Collections.emptySortedMap() : map;
     }
 
     @Override
     public void setContextMap(final Map<String, String> contextMap) {
         if (!enable) return;
-        if (contextMap == null) {
-            clear();
-            return;
-        }
+        clear();
+        if (contextMap == null) return;
         if (contextMap.keySet().contains(null))
             throw new IllegalArgumentException("key cannot be null");
         if (!allowNullValues && contextMap.values().contains(null))

--- a/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
@@ -16,7 +16,6 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
@@ -543,9 +542,10 @@ class LoggingEventTests {
     }
 
     @Test
-    void nullMdcGivesEmptyMdc() {
-        LoggingEvent event = new LoggingEvent(level, (Map<String, String>) null, message);
-        assertEquals(Collections.emptyMap(), event.getMdc());
+    void nullMdcThrowsNullPointerException() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new LoggingEvent(level, (Map<String, String>) null, message));
     }
 
     public interface TriFunction<A, B, C, R> {


### PR DESCRIPTION
This PR answers some of the concerns raised in #391 "Do we really need copies to be immutable?"

It turned out that the main issue was around the copy of the MDC returned by `TestMDCAdaptor.getCopyOfContextMap()`. The [specification in SLF4J](https://www.slf4j.org/apidocs/org/slf4j/MDC.html#getCopyOfContextMap--) says nothing about whether the copy is immutable. There is no reason for it to be so, since the returned objects is fully owned by the caller.

A related issue is that `LoggingEvent` creates its own copy of the returned object. This leads to excessive copying, in particular because the map is usually empty.

My solution:
 * Make `getCopyOfContextMap()` return a modifiable copy. This makes it unneccesary for the client to make yet another copy.
 * Create a new package private method `TestMDCAdaptor.getContextMap()` that returns a reference to map kept in the MDC adaptor. This is used by `TestLogger` when constructing a `LoggingEvent`.
 * `LoggingEvent` in turn makes its own copy of the MDC passed to the constructor. Before actually making a copy, it is checked whether the MDC is empty. If so, the (singleton) `Collections.emptySortedMap()` is called instead.

Furthermore, I have made it explicit that `LoggingEvent.getMdc()` returns a `SortedMap`. I have chosen this because having a well-defined ordering of the map makes it easier to spot discrepancies in case an assertion fails.

The changes I made for #392 unintentionally allowed an `mdc` argument transferred to the `LoggingEvent` constructor to be null. I have reverted that change.

I noticed that the specification for [`MDC.setContextMap`](https://www.slf4j.org/apidocs/org/slf4j/MDC.html#setContextMap-java.util.Map-) says that the current map is cleared before being replaced. I have corrected the code to reflect this.