### PR TITLE
Add full support for the SLF4J fluent logging API

### DIFF
--- a/src/main/java/com/github/valfirst/slf4jtest/TestLoggingEventBuilder.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLoggingEventBuilder.java
@@ -1,0 +1,134 @@
+package com.github.valfirst.slf4jtest;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.event.DefaultLoggingEvent;
+import org.slf4j.event.KeyValuePair;
+import org.slf4j.event.Level;
+import org.slf4j.event.LoggingEvent;
+import org.slf4j.helpers.CheckReturnValue;
+import org.slf4j.spi.DefaultLoggingEventBuilder;
+import org.slf4j.spi.LoggingEventBuilder;
+
+/**
+ * A {@link LoggingEventBuilder} which changes the following compared to {@link
+ * DefaultLoggingEventBuilder}:
+ *
+ * <ul>
+ *   <li>The {@link #toLoggingEvent} method is added to build the event without logging it.
+ *   <li>The return type of the fluent methods is {@link TestLoggingEventBuilder}. This allows
+ *       {@link #toLoggingEvent} to be used in a fluent manner.
+ *   <li>The {@link KeyValuePair} implementation overrides the {@link Object#equals} and {@link
+ *       Object#hashCode} methods. This allows tests for equality in test assertions.
+ * </ul>
+ */
+public class TestLoggingEventBuilder extends DefaultLoggingEventBuilder {
+
+    public TestLoggingEventBuilder(Logger logger, Level level) {
+        super(logger, level);
+        loggingEvent = new TestLoggingEvent(level, logger);
+    }
+
+    /** Build the event, without logging it. */
+    public LoggingEvent toLoggingEvent() {
+        return loggingEvent;
+    }
+
+    static class TestLoggingEvent extends DefaultLoggingEvent {
+
+        private List<KeyValuePair> keyValuePairs = null;
+
+        public TestLoggingEvent(Level level, Logger logger) {
+            super(level, logger);
+        }
+
+        @Override
+        public void addKeyValue(String key, Object value) {
+            if (keyValuePairs == null) keyValuePairs = new ArrayList<>();
+            keyValuePairs.add(new TestKeyValuePair(key, value));
+        }
+
+        @Override
+        public List<KeyValuePair> getKeyValuePairs() {
+            return keyValuePairs;
+        }
+    }
+
+    static class TestKeyValuePair extends KeyValuePair {
+        public TestKeyValuePair(String key, Object value) {
+            super(key, value);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof KeyValuePair)) return false;
+            KeyValuePair that = (KeyValuePair) o;
+            return Arrays.deepEquals(new Object[] {key, value}, new Object[] {that.key, that.value});
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.deepHashCode(new Object[] {key, value});
+        }
+    }
+
+    @CheckReturnValue
+    @Override
+    @SuppressWarnings("unchecked")
+    public TestLoggingEventBuilder setCause(Throwable cause) {
+        return (TestLoggingEventBuilder) super.setCause(cause);
+    }
+
+    @CheckReturnValue
+    @Override
+    public TestLoggingEventBuilder addMarker(Marker marker) {
+        return (TestLoggingEventBuilder) super.addMarker(marker);
+    }
+
+    @CheckReturnValue
+    @Override
+    @SuppressWarnings("unchecked")
+    public TestLoggingEventBuilder addArgument(Object p) {
+        return (TestLoggingEventBuilder) super.addArgument(p);
+    }
+
+    @CheckReturnValue
+    @Override
+    @SuppressWarnings("unchecked")
+    public TestLoggingEventBuilder addArgument(Supplier<?> objectSupplier) {
+        return (TestLoggingEventBuilder) super.addArgument(objectSupplier);
+    }
+
+    @CheckReturnValue
+    @Override
+    @SuppressWarnings("unchecked")
+    public TestLoggingEventBuilder addKeyValue(String key, Object value) {
+        return (TestLoggingEventBuilder) super.addKeyValue(key, value);
+    }
+
+    @CheckReturnValue
+    @Override
+    @SuppressWarnings("unchecked")
+    public TestLoggingEventBuilder addKeyValue(String key, Supplier<Object> valueSupplier) {
+        return (TestLoggingEventBuilder) super.addKeyValue(key, valueSupplier);
+    }
+
+    @CheckReturnValue
+    @Override
+    @SuppressWarnings("unchecked")
+    public TestLoggingEventBuilder setMessage(String message) {
+        return (TestLoggingEventBuilder) super.setMessage(message);
+    }
+
+    @CheckReturnValue
+    @Override
+    @SuppressWarnings("unchecked")
+    public TestLoggingEventBuilder setMessage(Supplier<String> messageSupplier) {
+        return (TestLoggingEventBuilder) super.setMessage(messageSupplier);
+    }
+}

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -306,3 +306,50 @@ configuration, use
 
     TestMDCAdapter.getInstance().restoreOptions();
 
+### Using the Fluent API
+From SLF4J version 2.0, there is a new fluent logging API.
+It allows writing code like
+
+    logger.atInfo().setMessage("With an argument {}")
+        .addArgument(() -> myObj.calculateValue())
+        .addMarker("ForYourEyesOnly").log();
+
+The `atInfo()` method returns a `LoggingEventBuilder` which is used to
+build the event and finally log it.
+
+If logging at INFO level is not enabled, a NOOP `LoggingEventBuilder` is 
+returned by `atInfo`. This means the lambda on the second line will not be
+executed, thus saving the overhead if the message is not logged.
+
+Note that it is possible to add multiple markers to an event, 
+which is not possible with the classic API.
+
+SLF4J Test uses the `TestLoggingEventBuilder`, which is a modified version of
+the `DefaultLoggingEventBuilder` of SLF4J.
+
+Creating an SLF4J Test `LoggingEvent` to compare against can be done
+in the classic way like
+
+    LoggingEvent.info(
+        MarkerFactory.getMarker("ForYourEyesOnly"),
+        "With an argument {}",
+        myObj.calculateValue());
+
+Alternatively, you can create the `LoggingEvent` from a an existing SLF4J
+logging event, like
+
+    
+    LoggingEvent.fromSlf4jEvent(
+        new TestLoggingEventBuilder(null, Level.INFO)
+            .setMessage("With an argument {}")
+            .addArgument(() -> myObj.calculateValue())
+            .addMarker(MarkerFactory.getMarker("ForYourEyesOnly"))
+            .toLoggingEvent());
+
+This approach is neccessary if you use the features available
+in the fluent API only. This includes multiple markers and key/value pairs.
+
+The `TestLoggingEventBuilder` adds the `toLoggingEvent` method
+to access the created event. Please note that the returned value is an
+`org.slf4j.event.LoggingEvent`,
+which is different from `com.github.valfirst.slf4jtest.LoggingEvent`.

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
@@ -84,7 +84,7 @@ class TestLoggerAssertionsTest {
             assertThatThrownBy(() -> assertions.hasLogged(event))
                     .isInstanceOf(AssertionError.class)
                     .hasMessage(
-                            "Failed to find event:\n  LoggingEvent{level=WARN, mdc={another=slightly different value, key=value}, marker=Optional.empty, throwable=Optional.empty, message='Something may be wrong', arguments=[]}"
+                            "Failed to find event:\n  LoggingEvent{level=WARN, mdc={another=slightly different value, key=value}, markers=[], keyValuePairs=[], throwable=Optional.empty, message='Something may be wrong', arguments=[]}"
                                     + loggerContainedMessage(loggingEvent));
         }
 
@@ -232,7 +232,7 @@ class TestLoggerAssertionsTest {
                                     () -> performAssert(loggerAssert, Level.WARN, "Something may be wrong"))
                             .isInstanceOf(AssertionError.class)
                             .hasMessage(
-                                    "Failed to find event:\n  LoggingEvent{level=WARN, mdc={}, marker=Optional.empty, throwable=Optional.empty, message='Something may be wrong', arguments=[]}"
+                                    "Failed to find event:\n  LoggingEvent{level=WARN, mdc={}, markers=[], keyValuePairs=[], throwable=Optional.empty, message='Something may be wrong', arguments=[]}"
                                             + loggerContainedMessage());
                 }
 
@@ -247,7 +247,7 @@ class TestLoggerAssertionsTest {
                                                     loggerAssert, Level.WARN, "Something may be wrong", "Extra context"))
                             .isInstanceOf(AssertionError.class)
                             .hasMessage(
-                                    "Failed to find event:\n  LoggingEvent{level=WARN, mdc={}, marker=Optional.empty, throwable=Optional.empty, message='Something may be wrong', arguments=[Extra context]}"
+                                    "Failed to find event:\n  LoggingEvent{level=WARN, mdc={}, markers=[], keyValuePairs=[], throwable=Optional.empty, message='Something may be wrong', arguments=[Extra context]}"
                                             + loggerContainedMessage(loggingEvent));
                 }
 
@@ -264,7 +264,7 @@ class TestLoggerAssertionsTest {
                                                     loggerAssert, Level.WARN, "Something may be wrong", "Extra context"))
                             .isInstanceOf(AssertionError.class)
                             .hasMessage(
-                                    "Failed to find event:\n  LoggingEvent{level=WARN, mdc={}, marker=Optional.empty, throwable=Optional.empty, message='Something may be wrong', arguments=[Extra context]}"
+                                    "Failed to find event:\n  LoggingEvent{level=WARN, mdc={}, markers=[], keyValuePairs=[], throwable=Optional.empty, message='Something may be wrong', arguments=[Extra context]}"
                                             + loggerContainedMessage(firstEvent, secondEvent));
                 }
 
@@ -283,7 +283,7 @@ class TestLoggerAssertionsTest {
                                                     "Another"))
                             .isInstanceOf(AssertionError.class)
                             .hasMessage(
-                                    "Failed to find event:\n  LoggingEvent{level=WARN, mdc={}, marker=Optional.empty, throwable=Optional.empty, message='Something may be wrong', arguments=[Extra context, Another]}"
+                                    "Failed to find event:\n  LoggingEvent{level=WARN, mdc={}, markers=[], keyValuePairs=[], throwable=Optional.empty, message='Something may be wrong', arguments=[Extra context, Another]}"
                                             + loggerContainedMessage(loggingEvent));
                 }
 
@@ -331,7 +331,7 @@ class TestLoggerAssertionsTest {
                                                     loggerAssert, throwable, Level.ERROR, "There was a problem!", "context"))
                             .isInstanceOf(AssertionError.class)
                             .hasMessage(
-                                    "Failed to find event:\n  LoggingEvent{level=ERROR, mdc={}, marker=Optional.empty, throwable=Optional[throwable], message='There was a problem!', arguments=[context]}"
+                                    "Failed to find event:\n  LoggingEvent{level=ERROR, mdc={}, markers=[], keyValuePairs=[], throwable=Optional[throwable], message='There was a problem!', arguments=[context]}"
                                             + loggerContainedMessage(loggingEvent));
                 }
 
@@ -344,7 +344,7 @@ class TestLoggerAssertionsTest {
                                     () -> performAssert(loggerAssert, throwable, Level.ERROR, "There was a problem!"))
                             .isInstanceOf(AssertionError.class)
                             .hasMessage(
-                                    "Failed to find event:\n  LoggingEvent{level=ERROR, mdc={}, marker=Optional.empty, throwable=Optional[throwable], message='There was a problem!', arguments=[]}"
+                                    "Failed to find event:\n  LoggingEvent{level=ERROR, mdc={}, markers=[], keyValuePairs=[], throwable=Optional[throwable], message='There was a problem!', arguments=[]}"
                                             + loggerContainedMessage(loggingEvent));
                 }
 
@@ -477,7 +477,7 @@ class TestLoggerAssertionsTest {
                 assertThatThrownBy(() -> performAssert(loggerAssert, Level.WARN, "Something may be wrong"))
                         .isInstanceOf(AssertionError.class)
                         .hasMessage(
-                                "Found LoggingEvent{level=WARN, mdc={}, marker=Optional.empty, throwable=Optional.empty, message='Something may be wrong', arguments=[]}, even though we expected not to");
+                                "Found LoggingEvent{level=WARN, mdc={}, markers=[], keyValuePairs=[], throwable=Optional.empty, message='Something may be wrong', arguments=[]}, even though we expected not to");
             }
 
             @Test
@@ -574,7 +574,7 @@ class TestLoggerAssertionsTest {
                                                     loggerAssert, throwable, Level.ERROR, "There was a problem!", "context"))
                             .isInstanceOf(AssertionError.class)
                             .hasMessage(
-                                    "Found LoggingEvent{level=ERROR, mdc={}, marker=Optional.empty, throwable=Optional[throwable], message='There was a problem!', arguments=[context]}, even though we expected not to");
+                                    "Found LoggingEvent{level=ERROR, mdc={}, markers=[], keyValuePairs=[], throwable=Optional[throwable], message='There was a problem!', arguments=[context]}, even though we expected not to");
                 }
 
                 @Test
@@ -586,7 +586,7 @@ class TestLoggerAssertionsTest {
                                     () -> performAssert(loggerAssert, throwable, Level.ERROR, "There was a problem!"))
                             .isInstanceOf(AssertionError.class)
                             .hasMessage(
-                                    "Found LoggingEvent{level=ERROR, mdc={}, marker=Optional.empty, throwable=Optional[throwable], message='There was a problem!', arguments=[]}, even though we expected not to");
+                                    "Found LoggingEvent{level=ERROR, mdc={}, markers=[], keyValuePairs=[], throwable=Optional[throwable], message='There was a problem!', arguments=[]}, even though we expected not to");
                 }
 
                 @Test

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggingEventBuilderTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggingEventBuilderTests.java
@@ -1,0 +1,66 @@
+package com.github.valfirst.slf4jtest;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.slf4j.event.Level.INFO;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+import org.slf4j.event.LoggingEvent;
+
+class TestLoggingEventBuilderTests {
+    @Test
+    void markers() {
+        final Marker marker1 = MarkerFactory.getMarker("1");
+        final Marker marker2 = MarkerFactory.getMarker("2");
+        TestLoggingEventBuilder builder = new TestLoggingEventBuilder(null, INFO);
+        builder.addMarker(marker1).addMarker(marker2);
+        LoggingEvent event = builder.toLoggingEvent();
+        assertThat(event.getMarkers(), is(asList(marker1, marker2)));
+    }
+
+    @Test
+    void keyValuePairs() {
+        LoggingEvent event =
+                new TestLoggingEventBuilder(null, INFO)
+                        .addKeyValue("KEY1", 1)
+                        .addKeyValue("KEY1", 2L)
+                        .toLoggingEvent();
+        List<TestLoggingEventBuilder.TestKeyValuePair> expected =
+                asList(
+                        new TestLoggingEventBuilder.TestKeyValuePair("KEY1", Integer.valueOf(1)),
+                        new TestLoggingEventBuilder.TestKeyValuePair("KEY1", Long.valueOf(2L)));
+        assertThat(event.getKeyValuePairs(), is(expected));
+    }
+
+    @Test
+    void noKeyValuePairs() {
+        LoggingEvent event = new TestLoggingEventBuilder(null, INFO).toLoggingEvent();
+        assertThat(event.getKeyValuePairs(), is(nullValue()));
+    }
+
+    @Test
+    void keyValuePairEqualsSame() {
+        TestLoggingEventBuilder.TestKeyValuePair pair =
+                new TestLoggingEventBuilder.TestKeyValuePair("x", "y");
+        assertThat(pair.equals(pair), is(true));
+    }
+
+    @Test
+    void keyValuePairNotEqualsNull() {
+        TestLoggingEventBuilder.TestKeyValuePair pair =
+                new TestLoggingEventBuilder.TestKeyValuePair("x", "y");
+        assertThat(pair.equals(null), is(false));
+    }
+
+    @Test
+    void keyValuePairHashCode() {
+        TestLoggingEventBuilder.TestKeyValuePair pair =
+                new TestLoggingEventBuilder.TestKeyValuePair(null, null);
+        assertThat(pair.hashCode(), is(961));
+    }
+}


### PR DESCRIPTION
This implements #407. Changes:
* The `TestLogger` class implements the `LoggingEventAware` interface. This means that it has direct access to the logging event produced by the fluent logging API, so it can store it more correctly. This breaks compatibility with SLF4J versions prior to 2.0.0.
* The `LoggingEvent` class supports multiple markers. This is allowed by the fluent API.
* The `LoggingEvent` class stores the key/value pair list that can be generated fluent API.
* The `toString`, `equals`, and `hashCode` methods of the `LoggingEvent` class have been updated to match the two changes above.
* The new `TestLoggingEventBuilder` class can be used for fluently creating `LoggingEvent` instances for use as expected values. That method is necessary if the expected event has key/value pairs or multiple markers. The alternative would have been to exponentially add even more convenience build routines to `LoggingEvent`. The existing ones are kept unchanged.
* Test cases that rely on the exact format of the output of `LoggingEvent.toString()` have been adapted.

BTW, I realized that there is nothing that prevents a logging event from having a null message, but `LoggingEvent.toString()` did not handle that. I have fixed it.