### PR TITLE
More changes for fluent logging API

### DIFF
--- a/src/main/java/com/github/valfirst/slf4jtest/TestLoggingEventBuilder.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLoggingEventBuilder.java
@@ -58,7 +58,13 @@ public class TestLoggingEventBuilder extends DefaultLoggingEventBuilder {
         }
     }
 
-    static class TestKeyValuePair extends KeyValuePair {
+    /**
+     * Extension of {@link KeyValuePair} with overridden {@link Object#equals} and {@link
+     * Object#hashCode} methods. This class must be used on the left hand side of {@link
+     * Object#equals} instead of {@link KeyValuePair}. {@link KeyValuePair} can be used on the right
+     * hand side.
+     */
+    public static class TestKeyValuePair extends KeyValuePair {
         public TestKeyValuePair(String key, Object value) {
             super(key, value);
         }

--- a/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/LoggingEventTests.java
@@ -72,7 +72,8 @@ class LoggingEventTests {
         LoggingEvent event = new LoggingEvent(level, message, arg1, arg2);
         assertThat(event.getLevel(), is(level));
         assertThat(event.getMdc(), is(emptyMap));
-        assertThat(event.getMarker(), is(empty()));
+        assertThat(event.getMarkers(), is(Collections.emptyList()));
+        assertThat(event.getKeyValuePairs(), is(Collections.emptyList()));
         assertThat(event.getThrowable(), is(empty()));
         assertThat(event.getMessage(), is(message));
         assertThat(event.getArguments(), is(args));
@@ -83,7 +84,8 @@ class LoggingEventTests {
         LoggingEvent event = new LoggingEvent(level, throwable, message, arg1, arg2);
         assertThat(event.getLevel(), is(level));
         assertThat(event.getMdc(), is(emptyMap));
-        assertThat(event.getMarker(), is(empty()));
+        assertThat(event.getMarkers(), is(Collections.emptyList()));
+        assertThat(event.getKeyValuePairs(), is(Collections.emptyList()));
         assertThat(event.getThrowable(), is(of(throwable)));
         assertThat(event.getMessage(), is(message));
         assertThat(event.getArguments(), is(args));
@@ -94,7 +96,8 @@ class LoggingEventTests {
         LoggingEvent event = new LoggingEvent(level, marker, message, arg1, arg2);
         assertThat(event.getLevel(), is(level));
         assertThat(event.getMdc(), is(emptyMap));
-        assertThat(event.getMarker(), is(of(marker)));
+        assertThat(event.getMarkers(), is(Collections.singletonList(marker)));
+        assertThat(event.getKeyValuePairs(), is(Collections.emptyList()));
         assertThat(event.getThrowable(), is(empty()));
         assertThat(event.getMessage(), is(message));
         assertThat(event.getArguments(), is(args));
@@ -105,7 +108,8 @@ class LoggingEventTests {
         LoggingEvent event = new LoggingEvent(level, marker, throwable, message, arg1, arg2);
         assertThat(event.getLevel(), is(level));
         assertThat(event.getMdc(), is(emptyMap));
-        assertThat(event.getMarker(), is(of(marker)));
+        assertThat(event.getMarkers(), is(Collections.singletonList(marker)));
+        assertThat(event.getKeyValuePairs(), is(Collections.emptyList()));
         assertThat(event.getThrowable(), is(of(throwable)));
         assertThat(event.getMessage(), is(message));
         assertThat(event.getArguments(), is(args));
@@ -116,7 +120,8 @@ class LoggingEventTests {
         LoggingEvent event = new LoggingEvent(level, mdc, message, arg1, arg2);
         assertThat(event.getLevel(), is(level));
         assertThat(event.getMdc(), is(mdc));
-        assertThat(event.getMarker(), is(empty()));
+        assertThat(event.getMarkers(), is(Collections.emptyList()));
+        assertThat(event.getKeyValuePairs(), is(Collections.emptyList()));
         assertThat(event.getThrowable(), is(empty()));
         assertThat(event.getMessage(), is(message));
         assertThat(event.getArguments(), is(args));
@@ -127,7 +132,8 @@ class LoggingEventTests {
         LoggingEvent event = new LoggingEvent(level, mdc, throwable, message, arg1, arg2);
         assertThat(event.getLevel(), is(level));
         assertThat(event.getMdc(), is(mdc));
-        assertThat(event.getMarker(), is(empty()));
+        assertThat(event.getMarkers(), is(Collections.emptyList()));
+        assertThat(event.getKeyValuePairs(), is(Collections.emptyList()));
         assertThat(event.getThrowable(), is(of(throwable)));
         assertThat(event.getMessage(), is(message));
         assertThat(event.getArguments(), is(args));
@@ -138,7 +144,8 @@ class LoggingEventTests {
         LoggingEvent event = new LoggingEvent(level, mdc, marker, message, arg1, arg2);
         assertThat(event.getLevel(), is(level));
         assertThat(event.getMdc(), is(mdc));
-        assertThat(event.getMarker(), is(of(marker)));
+        assertThat(event.getMarkers(), is(Collections.singletonList(marker)));
+        assertThat(event.getKeyValuePairs(), is(Collections.emptyList()));
         assertThat(event.getThrowable(), is(empty()));
         assertThat(event.getMessage(), is(message));
         assertThat(event.getArguments(), is(args));
@@ -149,7 +156,8 @@ class LoggingEventTests {
         LoggingEvent event = new LoggingEvent(level, mdc, marker, throwable, message, arg1, arg2);
         assertThat(event.getLevel(), is(level));
         assertThat(event.getMdc(), is(mdc));
-        assertThat(event.getMarker(), is(of(marker)));
+        assertThat(event.getMarkers(), is(Collections.singletonList(marker)));
+        assertThat(event.getKeyValuePairs(), is(Collections.emptyList()));
         assertThat(event.getThrowable(), is(of(throwable)));
         assertThat(event.getMessage(), is(message));
         assertThat(event.getArguments(), is(args));

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
@@ -17,6 +17,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.OngoingStubbing;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+import org.slf4j.event.KeyValuePair;
 import org.slf4j.event.Level;
 
 @ExtendWith(MockitoExtension.class)
@@ -618,6 +621,84 @@ class TestLoggerAssertionsTest {
             assertions.anyThread().hasLevel(Level.ERROR).hasNumberOfLogs(0);
 
             verify(logger).getAllLoggingEvents();
+        }
+    }
+
+    @Nested
+    @SuppressWarnings("deprecation")
+    class DeprecatedMarkerPredicate {
+        private Marker marker = MarkerFactory.getMarker("marker");
+
+        @Test
+        void isFalseWithMultipleMarkers() {
+            LoggingEvent event =
+                    LoggingEvent.fromSlf4jEvent(
+                            new TestLoggingEventBuilder(null, Level.ERROR)
+                                    .addMarker(marker)
+                                    .addMarker(marker)
+                                    .toLoggingEvent());
+            Predicate<LoggingEvent> predicate =
+                    new TestLoggerAssert.PredicateBuilder().withMarker(marker).build();
+            assertThat(predicate.test(event)).isFalse();
+        }
+
+        @Test
+        void isTrueWithOneMarker() {
+            LoggingEvent event =
+                    LoggingEvent.fromSlf4jEvent(
+                            new TestLoggingEventBuilder(null, Level.ERROR).addMarker(marker).toLoggingEvent());
+            Predicate<LoggingEvent> predicate =
+                    new TestLoggerAssert.PredicateBuilder().withMarker(marker).build();
+            assertThat(predicate.test(event)).isTrue();
+        }
+
+        @Test
+        void isTrueWithNoMarkers() {
+            LoggingEvent event =
+                    LoggingEvent.fromSlf4jEvent(
+                            new TestLoggingEventBuilder(null, Level.ERROR).toLoggingEvent());
+            Predicate<LoggingEvent> predicate =
+                    new TestLoggerAssert.PredicateBuilder().withMarker(null).build();
+            assertThat(predicate.test(event)).isTrue();
+        }
+    }
+
+    @Nested
+    class KeyValuePairsPredicate {
+        private Marker marker = MarkerFactory.getMarker("marker");
+
+        @Test
+        void isFalseInWrongOrder() {
+            LoggingEvent event =
+                    LoggingEvent.fromSlf4jEvent(
+                            new TestLoggingEventBuilder(null, Level.ERROR)
+                                    .addKeyValue("KEY1", Integer.valueOf(1111))
+                                    .addKeyValue("KEY2", Integer.valueOf(2222))
+                                    .toLoggingEvent());
+            Predicate<LoggingEvent> predicate =
+                    new TestLoggerAssert.PredicateBuilder()
+                            .withKeyValuePairs(
+                                    new KeyValuePair("KEY2", Integer.valueOf(2222)),
+                                    new KeyValuePair("KEY1", Integer.valueOf(1111)))
+                            .build();
+            assertThat(predicate.test(event)).isFalse();
+        }
+
+        @Test
+        void isTrueInCorrectOrder() {
+            LoggingEvent event =
+                    LoggingEvent.fromSlf4jEvent(
+                            new TestLoggingEventBuilder(null, Level.ERROR)
+                                    .addKeyValue("KEY1", Integer.valueOf(1111))
+                                    .addKeyValue("KEY2", Integer.valueOf(2222))
+                                    .toLoggingEvent());
+            Predicate<LoggingEvent> predicate =
+                    new TestLoggerAssert.PredicateBuilder()
+                            .withKeyValuePairs(
+                                    new KeyValuePair("KEY1", Integer.valueOf(1111)),
+                                    new KeyValuePair("KEY2", Integer.valueOf(2222)))
+                            .build();
+            assertThat(predicate.test(event)).isTrue();
         }
     }
 

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
@@ -677,9 +677,7 @@ class TestLoggerAssertionsTest {
                                     .toLoggingEvent());
             Predicate<LoggingEvent> predicate =
                     new TestLoggerAssert.PredicateBuilder()
-                            .withKeyValuePairs(
-                                    new KeyValuePair("KEY2", 2222),
-                                    new KeyValuePair("KEY1", 1111))
+                            .withKeyValuePairs(new KeyValuePair("KEY2", 2222), new KeyValuePair("KEY1", 1111))
                             .build();
             assertThat(predicate.test(event)).isFalse();
         }
@@ -694,9 +692,7 @@ class TestLoggerAssertionsTest {
                                     .toLoggingEvent());
             Predicate<LoggingEvent> predicate =
                     new TestLoggerAssert.PredicateBuilder()
-                            .withKeyValuePairs(
-                                    new KeyValuePair("KEY1", 1111),
-                                    new KeyValuePair("KEY2", 2222))
+                            .withKeyValuePairs(new KeyValuePair("KEY1", 1111), new KeyValuePair("KEY2", 2222))
                             .build();
             assertThat(predicate.test(event)).isTrue();
         }

--- a/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
+++ b/src/test/java/com/github/valfirst/slf4jtest/TestLoggerAssertionsTest.java
@@ -672,14 +672,14 @@ class TestLoggerAssertionsTest {
             LoggingEvent event =
                     LoggingEvent.fromSlf4jEvent(
                             new TestLoggingEventBuilder(null, Level.ERROR)
-                                    .addKeyValue("KEY1", Integer.valueOf(1111))
-                                    .addKeyValue("KEY2", Integer.valueOf(2222))
+                                    .addKeyValue("KEY1", 1111)
+                                    .addKeyValue("KEY2", 2222)
                                     .toLoggingEvent());
             Predicate<LoggingEvent> predicate =
                     new TestLoggerAssert.PredicateBuilder()
                             .withKeyValuePairs(
-                                    new KeyValuePair("KEY2", Integer.valueOf(2222)),
-                                    new KeyValuePair("KEY1", Integer.valueOf(1111)))
+                                    new KeyValuePair("KEY2", 2222),
+                                    new KeyValuePair("KEY1", 1111))
                             .build();
             assertThat(predicate.test(event)).isFalse();
         }
@@ -689,14 +689,14 @@ class TestLoggerAssertionsTest {
             LoggingEvent event =
                     LoggingEvent.fromSlf4jEvent(
                             new TestLoggingEventBuilder(null, Level.ERROR)
-                                    .addKeyValue("KEY1", Integer.valueOf(1111))
-                                    .addKeyValue("KEY2", Integer.valueOf(2222))
+                                    .addKeyValue("KEY1", 1111)
+                                    .addKeyValue("KEY2", 2222)
                                     .toLoggingEvent());
             Predicate<LoggingEvent> predicate =
                     new TestLoggerAssert.PredicateBuilder()
                             .withKeyValuePairs(
-                                    new KeyValuePair("KEY1", Integer.valueOf(1111)),
-                                    new KeyValuePair("KEY2", Integer.valueOf(2222)))
+                                    new KeyValuePair("KEY1", 1111),
+                                    new KeyValuePair("KEY2", 2222))
                             .build();
             assertThat(predicate.test(event)).isTrue();
         }


### PR DESCRIPTION
More changes related to #407.
* Changes to `TestLoggerAssert.PredicateBuilder` supporting key/value pairs and multiple markers.
* Additional test cases for the above.
* Updates to the checks in the constructor test cases in `LoggingEventTests`.