### PR TITLE
[CI] Run static code analysis on Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           fi;
 
       - name: Analyze with Codacy
-        if: matrix.java == '17'
+        if: matrix.java == '11'
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
           CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: mvn clean verify
 
       - name: Publish test coverage data to Coveralls
-        if: matrix.java == '11'
+        if: matrix.java == '17'
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           BRANCH_NAME_OR_REF: ${{ github.head_ref || github.ref }}
@@ -43,7 +43,7 @@ jobs:
           fi;
 
       - name: Analyze with Codacy
-        if: matrix.java == '11'
+        if: matrix.java == '17'
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
           CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
@@ -55,7 +55,7 @@ jobs:
           fi;
 
       - name: Analyze with SonarCloud
-        if: matrix.java == '11'
+        if: matrix.java == '17'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
https://docs.sonarcloud.io/appendices/scanner-environment/#java-configuration:
> JDK 11 is deprecated for scanner environments.