### PR TITLE
Optimize performance: pass empty array to `Collection#toArray` calls

### DIFF
--- a/src/main/java/com/github/valfirst/slf4jtest/TestLoggerAssert.java
+++ b/src/main/java/com/github/valfirst/slf4jtest/TestLoggerAssert.java
@@ -208,9 +208,8 @@ public class TestLoggerAssert extends AbstractTestLoggerAssert<TestLoggerAssert>
 
     private Predicate<LoggingEvent> buildPredicate(LoggingEvent event) {
         return new PredicateBuilder()
-                .withMarkers(event.getMarkers().toArray(new Marker[event.getMarkers().size()]))
-                .withKeyValuePairs(
-                        event.getKeyValuePairs().toArray(new KeyValuePair[event.getKeyValuePairs().size()]))
+                .withMarkers(event.getMarkers().toArray(new Marker[0]))
+                .withKeyValuePairs(event.getKeyValuePairs().toArray(new KeyValuePair[0]))
                 .withThrowable(event.getThrowable().orElse(null))
                 .withLevel(event.getLevel())
                 .withMessage(event.getMessage())


### PR DESCRIPTION
In older Java versions, using a pre-sized array was recommended, as the reflection call necessary to create an array of proper size was quite slow. However, since late updates of OpenJDK 6, this call was intrinsified, making the performance of the empty array version the same, and sometimes even better, compared to the pre-sized version.