### PR TITLE
Fix generation of POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>1.8</jdk.version>
+        <mockito.version>4.11.0</mockito.version>
+        <junit-pioneer.version>1.9.1</junit-pioneer.version>
         <pmd.version>7.16.0</pmd.version>
         <maven.surefire.version>3.5.3</maven.surefire.version>
     </properties>
@@ -499,10 +501,6 @@
             <activation>
                 <jdk>(,11)</jdk>
             </activation>
-            <properties>
-                <mockito.version>4.11.0</mockito.version>
-                <junit-pioneer.version>1.9.1</junit-pioneer.version>
-            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.mockito</groupId>


### PR DESCRIPTION
The POM publihed in 3.0.2 version (https://repo.maven.apache.org/maven2/com/github/valfirst/slf4j-test/3.0.2/slf4j-test-3.0.2.pom) is broken.
```
> Could not resolve com.github.valfirst:slf4j-test:3.0.2.
   > Could not parse POM https://repo.maven.apache.org/maven2/com/github/valfirst/slf4j-test/3.0.2/slf4j-test-3.0.2.pom
      > Could not find org.mockito:mockito-bom:${mockito.version}.
```