### PR TITLE
Activate Spotless on Java 17+ only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -518,12 +518,18 @@
                 <mockito.version>5.19.0</mockito.version>
                 <junit-pioneer.version>2.3.0</junit-pioneer.version>
             </properties>
+        </profile>
+        <profile>
+            <id>jdk-17-and-higher</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>com.diffplug.spotless</groupId>
                         <artifactId>spotless-maven-plugin</artifactId>
-                        <version>2.46.1</version>
+                        <version>3.0.0</version>
                         <configuration>
                             <java>
                                 <googleJavaFormat />


### PR DESCRIPTION
Spotless Mvaen plugin 3.0.0 requires Java 17 and higher: https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md